### PR TITLE
Bugfix for yaml db basepaths for --resume

### DIFF
--- a/commec/config/io_parameters.py
+++ b/commec/config/io_parameters.py
@@ -153,6 +153,8 @@ class ScreenIOParameters:
             base_paths = config_from_yaml["base_paths"]
             if db_dir_override is not None:
                 base_paths["default"] = db_dir_override
+            else:
+                self.db_dir = base_paths["default"]
 
             def recursive_format(d, base_paths):
                 """


### PR DESCRIPTION
## Background
Pulled this out of https://github.com/ibbis-bio/common-mechanism/pull/24/ so that it can be merged into the 0.3 release along with the YAML implementation.

### Bug fixes
* Fixed a bug relating to yaml --resume behaviour not correctly updating the existing db_dir value from yaml, when not overriding from cli.