### PR TITLE
Urgent CLI override defaults Bugfix

### DIFF
--- a/commec/cli.py
+++ b/commec/cli.py
@@ -13,7 +13,6 @@ Command-line usage:
     - commec flag /path/to/directory/with/output.screen 
     - commec split input.fasta
 """
-import argparse
 from commec.flag import (
     DESCRIPTION as flag_DESCRIPTION,
     add_args as flag_add_args,
@@ -23,6 +22,7 @@ from commec.screen import (
     DESCRIPTION as screen_DESCRIPTION,
     add_args as screen_add_args,
     run as screen_run,
+    ScreenArgumentParser
 )
 from commec.split import (
     DESCRIPTION as split_DESCRIPTION,
@@ -35,12 +35,11 @@ from commec.setup import (
     run as setup_run,
 )
 
-
 def main():
     """
     Parse the command line arguments and call the relevant sub-command.
     """
-    parser = argparse.ArgumentParser(
+    parser = ScreenArgumentParser(
         prog="commec", description="Command-line entrypoint for the Common Mechanism"
     )
     subparsers = parser.add_subparsers(dest="command")
@@ -62,6 +61,7 @@ def main():
     setup_add_args(setup_parser)
 
     args = parser.parse_args()
+
     if args.command == "screen":
         screen_run(args)
     elif args.command == "flag":

--- a/commec/config/io_parameters.py
+++ b/commec/config/io_parameters.py
@@ -20,25 +20,11 @@ from yaml.parser import ParserError
 from commec.config.query import Query
 from commec.config.constants import DEFAULT_CONFIG_YAML_PATH
 
-SCREEN_ARGS = {
-    "database_dir"       : ("-d", "--databases"),
-    "config_yaml"        : ("-y", "--config"),
-    "fast_mode"          : ("-f", "--fast"),
-    "protein_search_tool": ("-p", "--protein-search-tool"),
-    "skip_nt_search"     : ("-n", "--skip-nt"),
-    "threads"            : ("-t", "--threads"),
-    "diamond_jobs"       : ("-j", "--diamond-jobs"),
-    "output_prefix"      : ("-o", "--output"),
-    "cleanup"            : ("-c", "--cleanup"),
-    "force"              : ("-F", "--force"),
-    "resume"             : ("-R", "--resume"),
-}
-
 class ScreenIOParameters:
     """
     Container for input settings constructed from arguments to `screen`.
     """
-    def __init__(self, args: argparse.ArgumentParser):
+    def __init__(self, args: argparse.Namespace):
         # Non-yaml Inputs
         cli_config_yaml_filepath=args.config_yaml.strip()
         self.db_dir = args.database_dir
@@ -124,13 +110,16 @@ class ScreenIOParameters:
         return True
 
 
-    def _update_config_from_cli(self, args: argparse.ArgumentParser):
-        """ Maps any CLI, that can update the yaml configuration dictionary, and does so."""
+    def _update_config_from_cli(self, args: argparse.Namespace):
+        """ 
+        Maps any CLI, that can update the yaml 
+        configuration dictionary, and does so.
+        """
 
-        # Compare argv to args, to see what was actually passed in CLI:
-        known_commands = {k: v for k, v in vars(args).items() if SCREEN_ARGS.get(k)}
-        explicit_args = {k: v for k, v in known_commands.items() if SCREEN_ARGS[k][0] in sys.argv or SCREEN_ARGS[k][1] in sys.argv}
+        assert (hasattr(args, "user_specified_args"), 
+        "Incorrect argument parser used for Commec Screen.")
 
+        explicit_args = {k: v for k, v in vars(args).items() if k in args.user_specified_args}
         # Map argparse keys to YAML config keys, many are the same, and can be ignored.
         new_key_names = {
             "fast_mode" : "in_fast_mode",
@@ -301,4 +290,4 @@ class ScreenIOParameters:
 
     @property
     def should_do_benign_screening(self) -> bool:
-        return True# 
+        return True

--- a/commec/screen.py
+++ b/commec/screen.py
@@ -133,7 +133,7 @@ def add_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
     screen_logic_group.add_argument(
         "-f",
         "--fast",
-        dest="fast_mode",
+        dest="in_fast_mode",
         action="store_true",
         help="Run in fast mode and skip protein and nucleotide homology search",
     )
@@ -179,7 +179,7 @@ def add_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
     output_handling_group.add_argument(
         "-c",
         "--cleanup",
-        dest="cleanup",
+        dest="do_cleanup",
         action="store_true",
         help="Delete intermediate output files for this Screen run",
     )

--- a/commec/tests/test_io_params.py
+++ b/commec/tests/test_io_params.py
@@ -4,6 +4,7 @@ import os
 import argparse
 
 from commec.config.io_parameters import ScreenIOParameters
+from commec.cli import ScreenArgumentParser
 from commec.screen import add_args
 
 INPUT_QUERY = os.path.join(os.path.dirname(__file__), "test_data/single_record.fasta")
@@ -11,7 +12,7 @@ DATABASE_DIRECTORY = os.path.join(os.path.dirname(__file__), "test_dbs/")
 
 @patch("sys.argv", ["test_io_params.py", "-f", INPUT_QUERY, "-d", DATABASE_DIRECTORY, "-o", "output_test"])
 def test_default_parameters(tmp_path):
-    args = argparse.ArgumentParser()
+    args = ScreenArgumentParser()
     add_args(args)
     args = args.parse_args()
     args.output_prefix = tmp_path

--- a/commec/tests/test_io_params.py
+++ b/commec/tests/test_io_params.py
@@ -1,7 +1,7 @@
 import pytest
 from unittest.mock import patch
 import os
-import argparse
+import yaml
 
 from commec.config.io_parameters import ScreenIOParameters
 from commec.cli import ScreenArgumentParser
@@ -10,12 +10,140 @@ from commec.screen import add_args
 INPUT_QUERY = os.path.join(os.path.dirname(__file__), "test_data/single_record.fasta")
 DATABASE_DIRECTORY = os.path.join(os.path.dirname(__file__), "test_dbs/")
 
-@patch("sys.argv", ["test_io_params.py", "-f", INPUT_QUERY, "-d", DATABASE_DIRECTORY, "-o", "output_test"])
-def test_default_parameters(tmp_path):
+@pytest.fixture
+def expected_defaults():
+    return {
+        "base_paths": {
+            "default": "commec-dbs/"
+        },
+        "databases": {
+            "benign": {
+                "cm": {"path": "commec-dbs/benign_db/benign.cm"},
+                "fasta": {"path": "commec-dbs/benign_db/benign.fasta"},
+                "hmm": {"path": "commec-dbs/benign_db/benign.hmm"}
+            },
+            "biorisk_hmm": {
+                "path": "commec-dbs/biorisk_db/biorisk.hmm"
+            },
+            "regulated_nt": {
+                "path": "commec-dbs/nt_blast/nt"
+            },
+            "regulated_protein": {
+                "blast": {"path": "commec-dbs/nr_blast/nr"},
+                "diamond": {"path": "commec-dbs/nr_dmnd/nr.dmnd"}
+            }
+        },
+        "taxonomy": {
+            "taxonomy_directory": "commec-dbs/taxonomy/",
+            "regulated_vaxids": "commec-dbs/biorisk_db/vaxids.txt",
+            "benign_taxids": "commec-dbs/benign_db/taxids.txt"
+        },
+        "threads": 1,
+        "protein_search_tool": "blastx",
+        "in_fast_mode": False,
+        "skip_nt_search": False,
+        "do_cleanup": False,
+        "diamond_jobs": None,
+        "force": False,
+        "resume": False
+    }
+
+@pytest.fixture
+def custom_yaml_config():
+    return {
+        "databases": {
+            "taxonomy": {
+                "regulated_vaxids" : "custom_path.txt"
+            }
+        },
+        "in_fast_mode": True,
+        "force": True,
+        "threads": 8
+    }
+
+def test_missing_input_file():
     args = ScreenArgumentParser()
     add_args(args)
-    args = args.parse_args()
-    args.output_prefix = tmp_path
-    new_params = ScreenIOParameters(args)
-    assert new_params.setup()
+    with pytest.raises(SystemExit):
+        args = args.parse_args()
+    
+def test_default_config_only(expected_defaults):
+    """Test that default config is loaded when no overrides exist"""
+    parser = ScreenArgumentParser()
+    add_args(parser)
+    args = parser.parse_args([INPUT_QUERY])
+    params = ScreenIOParameters(args)
+    
+    assert expected_defaults == params.config
+
+def test_user_yaml_override(tmp_path, expected_defaults, custom_yaml_config):
+    """Test that user YAML properly overrides default config"""
+    # Create user config
+    user_config_path = tmp_path / "user_config.yaml"
+    with open(user_config_path, 'w') as f:
+        yaml.dump(custom_yaml_config, f)
+    
+    parser = ScreenArgumentParser()
+    add_args(parser)
+    args = parser.parse_args([INPUT_QUERY, "--config", str(user_config_path)])
+    params = ScreenIOParameters(args)
+    
+    # Check that user YAML values override defaults
+    expected_defaults.update(custom_yaml_config)
+
+    assert expected_defaults == params.config
+
+def test_cli_override(tmp_path, expected_defaults, custom_yaml_config):
+    """Test that CLI args properly override both YAML configs"""
+    # Create user config
+    user_config_path = tmp_path / "user_config.yaml"
+    with open(user_config_path, 'w') as f:
+        yaml.dump(custom_yaml_config, f)
+
+    # Add CLI args
+    cli_args = [
+        INPUT_QUERY,
+        "--config",
+        str(user_config_path),
+        "-F", # fast mode
+        "--skip-nt", # skip nt search
+        "-d",
+        str(tmp_path)
+    ]
+
+    parser = ScreenArgumentParser()
+    add_args(parser)
+    args = parser.parse_args(cli_args)
+    params = ScreenIOParameters(args)
+    
+    # Override defaults with user YAML
+    expected_defaults.update(custom_yaml_config)
+    expected_defaults["skip_nt_search"] = True
+    db_str_to_override = expected_defaults["base_paths"]["default"]
+
+    def recursive_override(dictionary, str_to_override, override_str):
+        """
+        Recursively apply string formatting to read paths from nested yaml config dicts.
+        """
+        if isinstance(dictionary, dict):
+            return {key : recursive_override(value, str_to_override, override_str) 
+                    for key, value in dictionary.items()}
+        if isinstance(dictionary, str):
+           return dictionary.replace(str_to_override, override_str)
+        return dictionary
+    
+    expected_defaults = recursive_override(expected_defaults, db_str_to_override, str(tmp_path))
+
+    assert expected_defaults == params.config
+
+def test_missing_default_config():
+    """Test that missing default config raises appropriate error"""
+    with patch("importlib.resources.files") as mock_files:
+        mock_files.return_value.joinpath.return_value.exists.return_value = False
+        args = ScreenArgumentParser()
+        add_args(args)
+        args = args.parse_args([INPUT_QUERY])
+        
+        with pytest.raises(FileNotFoundError, match="No default yaml found"):
+            _ = ScreenIOParameters(args)
 

--- a/commec/tests/test_io_params.py
+++ b/commec/tests/test_io_params.py
@@ -105,8 +105,9 @@ def test_cli_override(tmp_path, expected_defaults, custom_yaml_config):
         INPUT_QUERY,
         "--config",
         str(user_config_path),
-        "-F", # fast mode
+        "-f", # fast mode
         "--skip-nt", # skip nt search
+        "-c", # do_cleanup
         "-d",
         str(tmp_path)
     ]
@@ -119,6 +120,7 @@ def test_cli_override(tmp_path, expected_defaults, custom_yaml_config):
     # Override defaults with user YAML
     expected_defaults.update(custom_yaml_config)
     expected_defaults["skip_nt_search"] = True
+    expected_defaults["do_cleanup"] = True
     db_str_to_override = expected_defaults["base_paths"]["default"]
 
     def recursive_override(dictionary, str_to_override, override_str):


### PR DESCRIPTION
Settings provided in CLI , with hyphens, or when provided in shorthand format (-n, instead of -skip-nt) for example, were not correctly being updated, and would not change the runs configuration from the defaults.

This fixes this issue by updating the logic on matching argv to the argsparse args object.
This was affecting the following CLI commands:
skip nt, fast mode, protein search tool, diamond jobs, all shorthand variations.


## Changes
Side effect includes the storage of shorthand and longhand command line arguments to be stored in a constant dictionary within screenio.py. This was done to ensure that the declaration of args within screen.py wasn't hard coding its own definitions, and connects the declaration directly to the logic used to detect those args - this was deemed preferable to passing the parser object, instead of args, down the call chain from run() to screenio.py init.

### Bug fixes
many CLI commands now correctly override defaults.

### Refactoring
Shorthand and longhand CLI commands for screen now stored in screenio.py dict.
