### PR TITLE
Simple bug-fix for --protein-search-tool to the double hypen.

### DIFF
--- a/commec/screen.py
+++ b/commec/screen.py
@@ -139,7 +139,7 @@ def add_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
     )
     screen_logic_group.add_argument(
         "-p",
-        "-protein-search-tool",
+        "--protein-search-tool",
         dest="protein_search_tool",
         choices=["blastx", "diamond"],
         help="Tool for protein homology search to identify regulated pathogens",


### PR DESCRIPTION
## Background
-protein-search-tool should be --protein-search-tool.

**Issues**:
Current issue with expected double hyphen usage not applying to this single CLI command.

## Changes
Added double hyphen to --protein-search-tool
