### PR TITLE
Output formatting fixes

### DIFF
--- a/commec/config/query.py
+++ b/commec/config/query.py
@@ -51,13 +51,20 @@ class Query:
             )
 
     @staticmethod
-    def create_id(name : str) -> str:
+    def create_id(input_name : str) -> str:
         """
         Parse the Fasta SeqRecord string ID into 
         a 25 digit maximum Unique Identification.
         For internal Commec Screen Use only.
         Original Fasta name IDs are used during JSON output.
         """
+        # Protections on split name conventions for translation output:
+        name = input_name.split('|')[0]
+
+        # Protection on accidentally ending with _
+        if name.endswith("_"):
+            name = name[:-1]
+
         if len(name) < 26:
             return name
         
@@ -68,7 +75,7 @@ class Query:
             if len(testname) > 25:
                 break
             output = testname
-        
+
         return output
     
 

--- a/commec/config/result.py
+++ b/commec/config/result.py
@@ -253,7 +253,19 @@ class QueryScreenStatus:
         Parses the query status across all screening steps, then updates overall flag.
         Designed to be called at any time after Step 1.
         """
-        if self.benign_status is not ScreenStatus.NULL:
+        if ScreenStatus.ERROR in {
+            self.biorisk_status,
+            self.protein_taxonomy_status,
+            self.nucleotide_taxonomy_status,
+            self.benign_status
+        }:
+            self.screen_status = ScreenStatus.ERROR
+            return
+
+        if self.benign_status not in {
+            ScreenStatus.NULL, 
+            ScreenStatus.SKIP
+        }:
             self.screen_status = self.benign_status
             return
 

--- a/commec/config/result.py
+++ b/commec/config/result.py
@@ -30,8 +30,8 @@ import re
 from dataclasses import dataclass, asdict, field
 from typing import List, Iterator, Tuple
 from enum import StrEnum
-import pandas as pd
 from importlib.metadata import version, PackageNotFoundError
+import pandas as pd
 from commec.tools.search_handler import SearchToolVersion
 
 try:
@@ -240,14 +240,6 @@ class QueryScreenStatus:
         Designed to be called at any time after Step 1.
         """
         if self.benign_status is not ScreenStatus.NULL:
-
-
-        #if self.benign_status in {
-        #    ScreenStatus.CLEARED_FLAG,
-        #    ScreenStatus.CLEARED_WARN,
-        #    ScreenStatus.WARN,
-        #    ScreenStatus.PASS,
-        #}:
             self.screen_status = self.benign_status
             return
 
@@ -362,7 +354,6 @@ class QueryResult:
 
         self.recommendation.update_query_flag()
 
-
     def update(self):
         """
         Call this before exporting to file.
@@ -378,6 +369,7 @@ class QueryResult:
         )
         self.hits = dict(sorted_items_desc)
         self._update_step_flags()
+
 
 @dataclass 
 class SearchToolInfo:
@@ -446,11 +438,11 @@ class ScreenResult:
                 yield query, hit
 
     def get_flag_data(self) -> pd.DataFrame:
-
-        #columns = ["query", "overall", "biorisk", "taxonomy protein", "taxonomy nt", "benign"]
-
+        """
+        Returns a dataframe containing the status' from each screen step.
+        Useful for printing summary information.
+        """
         data = []
-
         for query in self.queries.values():
             data.append({
                 "query": query.query[:25],

--- a/commec/config/result.py
+++ b/commec/config/result.py
@@ -43,7 +43,7 @@ except PackageNotFoundError:
     COMMEC_VERSION = "error"
 
 # Seperate versioning for the output JSON.
-JSON_COMMEC_FORMAT_VERSION = "0.1"
+JSON_COMMEC_FORMAT_VERSION = "0.2"
 
 
 class ScreenStatus(StrEnum):

--- a/commec/config/result.py
+++ b/commec/config/result.py
@@ -108,7 +108,18 @@ class ScreenStatus(StrEnum):
         if self == ScreenStatus.FLAG:
             return ScreenStatus.CLEARED_FLAG
         return self
+    
+    def __gt__(self, value):
+        return self.importance > value.importance
 
+    def __lt__(self, value):
+        return self.importance < value.importance
+
+    def __ge__(self, value):
+        return self.importance >= value.importance
+
+    def __le__(self, value):
+        return self.importance <= value.importance
 
 def compare(a: ScreenStatus, b: ScreenStatus):
     """

--- a/commec/config/result.py
+++ b/commec/config/result.py
@@ -379,30 +379,25 @@ class QueryResult:
         self.hits = dict(sorted_items_desc)
         self._update_step_flags()
 
-        
+@dataclass 
+class SearchToolInfo:
+    """ Container to hold version info for search tools and databases used. """
+    biorisk_search_info:        SearchToolVersion = field(default_factory=SearchToolVersion)
+    protein_search_info:        SearchToolVersion = field(default_factory=SearchToolVersion)
+    nucleotide_search_info:     SearchToolVersion = field(default_factory=SearchToolVersion)
+    benign_protein_search_info: SearchToolVersion = field(default_factory=SearchToolVersion)
+    benign_rna_search_info:     SearchToolVersion = field(default_factory=SearchToolVersion)
+    benign_dna_search_info:     SearchToolVersion = field(default_factory=SearchToolVersion)
+
 
 @dataclass
 class ScreenRunInfo:
     """Container dataclass to hold general run information for a commec screen"""
-
     commec_version: str = str(COMMEC_VERSION)
     json_output_version: str = JSON_COMMEC_FORMAT_VERSION
-    biorisk_database_info: SearchToolVersion = field(default_factory=SearchToolVersion)
-    protein_database_info: SearchToolVersion = field(default_factory=SearchToolVersion)
-    nucleotide_database_info: SearchToolVersion = field(
-        default_factory=SearchToolVersion
-    )
-    benign_protein_database_info: SearchToolVersion = field(
-        default_factory=SearchToolVersion
-    )
-    benign_rna_database_info: SearchToolVersion = field(
-        default_factory=SearchToolVersion
-    )
-    benign_synbio_database_info: SearchToolVersion = field(
-        default_factory=SearchToolVersion
-    )
     time_taken: str = ""
     date_run: str = ""
+    search_tool_info: SearchToolInfo = field(default_factory=SearchToolInfo)
 
 
 @dataclass

--- a/commec/config/result.py
+++ b/commec/config/result.py
@@ -124,12 +124,12 @@ class ScreenStep(StrEnum):
     Enumeration of the Steps for Commec screening
     """
 
-    BIORISK = "Biorisk Screen"
-    TAXONOMY_NT = "Nucleotide Taxonomy Screen"
-    TAXONOMY_AA = "Protein Taxonomy Screen"
-    BENIGN_PROTEIN = "Benign Protein Screen"
-    BENIGN_RNA = "Benign RNA Screen"
-    BENIGN_SYNBIO = "Benign SynBio Screen"
+    BIORISK = "Biorisk Search"
+    TAXONOMY_NT = "Nucleotide Taxonomy Search"
+    TAXONOMY_AA = "Protein Taxonomy Search"
+    BENIGN_PROTEIN = "Benign Protein Search"
+    BENIGN_RNA = "Benign RNA Search"
+    BENIGN_DNA = "Benign DNA Search"
 
 
 @dataclass
@@ -356,7 +356,7 @@ class QueryResult:
                 case ScreenStep.BENIGN_RNA:
                     self.recommendation.benign_status = compare(
                         self.recommendation.benign_status, hit.recommendation.status)
-                case ScreenStep.BENIGN_SYNBIO:
+                case ScreenStep.BENIGN_DNA:
                     self.recommendation.benign_status = compare(
                         self.recommendation.benign_status, hit.recommendation.status)
 

--- a/commec/config/result.py
+++ b/commec/config/result.py
@@ -414,10 +414,6 @@ class ScreenResult:
     commec_info: ScreenRunInfo = field(default_factory=ScreenRunInfo)
     queries: dict[str, QueryResult] = field(default_factory=dict)
 
-    def format(self):
-        """Format this ScreenResult as a json string to pass to a standard out if desired."""
-        return str(asdict(self))
-
     def get_query(self, query_name: str) -> QueryResult:
         """
         Wrapper for Query get logic.
@@ -475,4 +471,7 @@ class ScreenResult:
 
     def __str__(self):
         df = self.get_flag_data()
-        return df.to_string()
+        return df.to_string(index=False, col_space = 12)
+    
+    def __repr__(self):
+        return str(asdict(self))

--- a/commec/config/result.py
+++ b/commec/config/result.py
@@ -280,7 +280,7 @@ class QueryResult:
 
     query: str = ""
     length: int = 0
-    sequence: str = ""
+    #sequence: str = ""
     recommendation: QueryScreenStatus = field(default_factory=QueryScreenStatus)
     hits: dict[str, HitResult] = field(default_factory=dict)
 
@@ -391,14 +391,20 @@ class ScreenRunInfo:
     date_run: str = ""
     search_tool_info: SearchToolInfo = field(default_factory=SearchToolInfo)
 
+@dataclass
+class ScreenQueryInfo:
+    """ Container for summarising the query input data """
+    file: str = ""
+    number_of_queries: int = 0
+    total_query_length: int = 0
 
 @dataclass
 class ScreenResult:
     """
     Root dataclass to hold all data related to the screening of an individual query by commec.
     """
-
     commec_info: ScreenRunInfo = field(default_factory=ScreenRunInfo)
+    query_info: ScreenQueryInfo = field(default_factory=ScreenQueryInfo)
     queries: dict[str, QueryResult] = field(default_factory=dict)
 
     def get_query(self, query_name: str) -> QueryResult:

--- a/commec/config/screen_io.py
+++ b/commec/config/screen_io.py
@@ -32,7 +32,7 @@ class ScreenIO:
     def __init__(self, args: argparse.Namespace):
         # Inputs that do no have a package-level default, since they are specific to each run
         self.db_dir = args.database_dir
-        self.input_fasta_path = args.fasta_file
+        self.input_fasta_path = os.path.abspath(args.fasta_file)
         output_prefix = args.output_prefix
 
         # Output folder hierarchy

--- a/commec/screen.py
+++ b/commec/screen.py
@@ -295,6 +295,7 @@ class Screen:
 
         try:
             for query in self.queries.values():
+                logger.debug("Processing query: %s, (%s)", query.name, query.original_name)
                 query.translate(self.params.nt_path, self.params.aa_path)
                 total_query_length += len(query.seq_record)
                 qr = QueryResult(query.original_name,

--- a/commec/screen.py
+++ b/commec/screen.py
@@ -305,16 +305,16 @@ class Screen:
 
         # Initialize the version info for all the databases
         _tools = self.database_tools
-        _info = self.screen_data.commec_info
-        _info.biorisk_database_info = _tools.biorisk_hmm.get_version_information()
+        _info = self.screen_data.commec_info.search_tool_info
+        _info.biorisk_search_info = _tools.biorisk_hmm.get_version_information()
         if self.params.should_do_protein_screening:
-            _info.protein_database_info = _tools.regulated_protein.get_version_information()
+            _info.protein_search_info = _tools.regulated_protein.get_version_information()
         if self.params.should_do_nucleotide_screening:
-            _info.nucleotide_database_info = _tools.regulated_nt.get_version_information()
+            _info.nucleotide_search_info = _tools.regulated_nt.get_version_information()
         if self.params.should_do_benign_screening:
-            _info.benign_protein_database_info = _tools.benign_hmm.get_version_information()
-            _info.benign_rna_database_info = _tools.benign_cmscan.get_version_information()
-            _info.benign_synbio_database_info = _tools.benign_blastn.get_version_information()
+            _info.benign_protein_search_info = _tools.benign_hmm.get_version_information()
+            _info.benign_rna_search_info = _tools.benign_cmscan.get_version_information()
+            _info.benign_dna_search_info = _tools.benign_blastn.get_version_information()
 
         # Store start time.
         _info.date_run = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
@@ -394,7 +394,7 @@ class Screen:
             self.reset_benign_recommendations(ScreenStatus.SKIP)
 
         logger.info(
-            " >> COMPLETED AT %s", datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            " >> Commec Screen completed at %s", datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         )
 
         self.screen_data.update()

--- a/commec/screen.py
+++ b/commec/screen.py
@@ -332,11 +332,11 @@ class Screen:
             logger.info(" >> STEP 1: Checking for biorisk genes...")
             self.screen_biorisks()
             logger.info(
-                " >> STEP 1 completed at %s",
+                "STEP 1 completed at %s",
                 datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
             )
         except Exception as e:
-            logger.info(" ERROR STEP 1: Biorisk search failed due to an error:\n %s", str(e))
+            logger.error("STEP 1: Biorisk search failed due to an error:\n %s", str(e))
             logger.info(" Traceback:\n%s", traceback.format_exc())
             self.reset_biorisk_recommendations(ScreenStatus.ERROR)
 
@@ -346,15 +346,15 @@ class Screen:
                 logger.info(" >> STEP 2: Checking regulated pathogen proteins...")
                 self.screen_proteins()
                 logger.info(
-                    " >> STEP 2 completed at %s",
+                    "STEP 2 completed at %s",
                     datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
                 )
             except Exception as e:
-                logger.info(" ERROR STEP 2: Protein search failed due to an error:\n %s", str(e))
+                logger.error("STEP 2: Protein search failed due to an error:\n %s", str(e))
                 logger.info(" Traceback:\n%s", traceback.format_exc())
                 self.reset_protein_recommendations(ScreenStatus.ERROR)
         else:
-            logger.info(" >> SKIPPING STEP 2: Protein search")
+            logger.info("SKIPPING STEP 2: Protein search")
             self.reset_protein_recommendations(ScreenStatus.SKIP)
 
         # Taxonomy screen (Nucleotide)
@@ -363,15 +363,15 @@ class Screen:
                 logger.info(" >> STEP 3: Checking regulated pathogen nucleotides...")
                 self.screen_nucleotides()
                 logger.info(
-                    " >> STEP 3 completed at %s",
+                    "STEP 3 completed at %s",
                     datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
                 )
             except Exception as e:
-                logger.info(" ERROR STEP 3: Nucleotide search failed due to an error:\n %s", str(e))
+                logger.error("ERROR STEP 3: Nucleotide search failed due to an error:\n %s", str(e))
                 logger.info(" Traceback:\n%s", traceback.format_exc())
                 self.reset_nucleotide_recommendations(ScreenStatus.ERROR)
         else:
-            logger.info(" >> SKIPPING STEP 3: Nucleotide search")
+            logger.info("SKIPPING STEP 3: Nucleotide search")
             self.reset_nucleotide_recommendations(ScreenStatus.SKIP)
 
         # Benign Screen
@@ -382,15 +382,15 @@ class Screen:
                 )
                 self.screen_benign()
                 logger.info(
-                    " >> STEP 4 completed at %s",
+                    "STEP 4 completed at %s",
                     datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
                 )
             except Exception as e:
-                logger.info(" ERROR STEP 4: Benign search failed due to an error:\n %s", str(e))
+                logger.error("STEP 4: Benign search failed due to an error:\n %s", str(e))
                 logger.info(" Traceback:\n%s", traceback.format_exc())
                 self.reset_benign_recommendations(ScreenStatus.ERROR)
         else:
-            logger.info(" >> SKIPPING STEP 4: Benign search")
+            logger.info(" << SKIPPING STEP 4: Benign search")
             self.reset_benign_recommendations(ScreenStatus.SKIP)
 
         logger.info(

--- a/commec/screen.py
+++ b/commec/screen.py
@@ -291,17 +291,24 @@ class Screen:
             logger.error(e)
             sys.exit()
 
+        total_query_length = 0
+
         try:
             for query in self.queries.values():
                 query.translate(self.params.nt_path, self.params.aa_path)
+                total_query_length += len(query.seq_record)
                 qr = QueryResult(query.original_name,
-                                    len(query.seq_record),
-                                    str(query.seq_record.seq))
+                                    len(query.seq_record))
+                                    #str(query.seq_record.seq))
                 self.screen_data.queries[query.name] = qr
                 query.result_handle = qr
         except RuntimeError as e:
             logger.error(e)
             sys.exit()
+
+        self.screen_data.query_info.file = self.params.input_fasta_path
+        self.screen_data.query_info.number_of_queries = len(self.queries.values())
+        self.screen_data.query_info.total_query_length = total_query_length
 
         # Initialize the version info for all the databases
         _tools = self.database_tools

--- a/commec/screen.py
+++ b/commec/screen.py
@@ -329,10 +329,10 @@ class Screen:
         
         # Biorisk screen
         try:
-            logger.info(">> STEP 1: Checking for biorisk genes...")
+            logger.info(" >> STEP 1: Checking for biorisk genes...")
             self.screen_biorisks()
             logger.info(
-                " STEP 1 completed at %s",
+                " >> STEP 1 completed at %s",
                 datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
             )
         except Exception as e:
@@ -346,7 +346,7 @@ class Screen:
                 logger.info(" >> STEP 2: Checking regulated pathogen proteins...")
                 self.screen_proteins()
                 logger.info(
-                    " STEP 2 completed at %s",
+                    " >> STEP 2 completed at %s",
                     datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
                 )
             except Exception as e:
@@ -354,7 +354,7 @@ class Screen:
                 logger.info(" Traceback:\n%s", traceback.format_exc())
                 self.reset_protein_recommendations(ScreenStatus.ERROR)
         else:
-            logger.info(" SKIPPING STEP 2: Protein search")
+            logger.info(" >> SKIPPING STEP 2: Protein search")
             self.reset_protein_recommendations(ScreenStatus.SKIP)
 
         # Taxonomy screen (Nucleotide)
@@ -363,7 +363,7 @@ class Screen:
                 logger.info(" >> STEP 3: Checking regulated pathogen nucleotides...")
                 self.screen_nucleotides()
                 logger.info(
-                    " STEP 3 completed at %s",
+                    " >> STEP 3 completed at %s",
                     datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
                 )
             except Exception as e:
@@ -371,18 +371,18 @@ class Screen:
                 logger.info(" Traceback:\n%s", traceback.format_exc())
                 self.reset_nucleotide_recommendations(ScreenStatus.ERROR)
         else:
-            logger.info(" SKIPPING STEP 3: Nucleotide search")
+            logger.info(" >> SKIPPING STEP 3: Nucleotide search")
             self.reset_nucleotide_recommendations(ScreenStatus.SKIP)
 
         # Benign Screen
         if self.params.should_do_benign_screening:
             try:
                 logger.info(
-                    ">> STEP 4: Checking any pathogen regions for benign components..."
+                    " >> STEP 4: Checking any pathogen regions for benign components..."
                 )
                 self.screen_benign()
                 logger.info(
-                    ">> STEP 4 completed at %s",
+                    " >> STEP 4 completed at %s",
                     datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
                 )
             except Exception as e:
@@ -390,15 +390,15 @@ class Screen:
                 logger.info(" Traceback:\n%s", traceback.format_exc())
                 self.reset_benign_recommendations(ScreenStatus.ERROR)
         else:
-            logger.info(" SKIPPING STEP 4: Benign search")
+            logger.info(" >> SKIPPING STEP 4: Benign search")
             self.reset_benign_recommendations(ScreenStatus.SKIP)
 
         logger.info(
-            ">> COMPLETED AT %s", datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            " >> COMPLETED AT %s", datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         )
 
         self.screen_data.update()
-        logger.info("SUMMARY: \n%s", self.screen_data)
+        logger.info(" >> SUMMARY: \n%s", self.screen_data)
         self.success = True
 
 

--- a/commec/screeners/check_benign.py
+++ b/commec/screeners/check_benign.py
@@ -220,7 +220,7 @@ def _filter_benign_synbio(query : Query,
     logger.debug("Processing Benign Hit: %s", benign_hit_outcome)
     
     if hit.recommendation.status not in {ScreenStatus.CLEARED_FLAG, ScreenStatus.CLEARED_WARN}:
-        logger.info("\t --> Clearing %s %s region %i-%i as Synthetic, for %s, with Synthetic %s",
+        logger.info("\t --> Clearing %s %s region %i-%i as Benign Nucleotide, for %s, with Synthetic Biology Part %s",
                         hit.recommendation.status, hit.name, region.query_start, region.query_end, query.name, benign_hit_outcome.name)
         hit.recommendation.status = hit.recommendation.status.clear()
 

--- a/commec/screeners/check_benign.py
+++ b/commec/screeners/check_benign.py
@@ -68,8 +68,8 @@ def _filter_benign_proteins(query : Query,
         benign_protein_for_query_trimmed["coverage_nt"] > MINIMUM_PEPTIDE_COVERAGE]
 
     if benign_protein_for_query_trimmed.empty:
-        logger.info("Not enough housekeeping protein coverage to clear %s found in %s",
-        hit.name, query.name)
+        logger.info("\t --> Insufficient coverage (<%i bp) for housekeeping protein to clear %s (%i-%i).",
+        int(MINIMUM_PEPTIDE_COVERAGE), hit.name, region.query_start, region.query_end)
         return []
 
     # Ensure that this benign hit covers at least 80% of the regulated region.
@@ -79,8 +79,8 @@ def _filter_benign_proteins(query : Query,
     benign_protein_for_query_trimmed = benign_protein_for_query_trimmed.reset_index(drop=True)
 
     if benign_protein_for_query_trimmed.empty:
-        logger.info("\t --> Housekeeping protein to clear %s (%i-%i), insufficiently covers query %s",
-        hit.name, region.query_start, region.query_end, query.name)
+        logger.info("\t --> Insufficient coverage (<%i%%) for housekeeping protein to clear %s (%i-%i).",
+        int(MINIMUM_QUERY_COVERAGE_FRACTION*100), hit.name, region.query_start, region.query_end)
         return []
 
     # Report top hit for Protein / RNA / Synbio
@@ -106,8 +106,8 @@ def _filter_benign_proteins(query : Query,
 
     # Rarely, something can be cleared that is already cleared, no need to report on that.
     if hit.recommendation.status not in {ScreenStatus.CLEARED_FLAG, ScreenStatus.CLEARED_WARN}:
-        logger.info("\t --> Clearing %s (%s) as house-keeping protein, for %s with Housekeeping Protein %s",
-                        hit.name, hit.recommendation.status, query.name, benign_hit_outcome.name)
+        logger.info("\t --> Clearing %s (%s) with house-keeping protein, %s",
+                        hit.name, hit.recommendation.status, benign_hit_outcome.name)
         hit.recommendation.status = hit.recommendation.status.clear()
 
     return [benign_hit_outcome]
@@ -159,13 +159,13 @@ def _filter_benign_rna(query : Query,
             )
         
         if hit.recommendation.status not in {ScreenStatus.CLEARED_FLAG, ScreenStatus.CLEARED_WARN}:
-            logger.info("\t --> Clearing %s %s (region %i-%i) for %s, with benign RNA %s",
-                        hit.recommendation.status, hit.name, region.query_start, region.query_end, query.name, benign_hit_outcome.name)
+            logger.info("\t --> Clearing %s %s (region %i-%i), with Benign RNA %s",
+                        hit.recommendation.status, hit.name, region.query_start, region.query_end, benign_hit_outcome.name)
             hit.recommendation.status = hit.recommendation.status.clear()
         return [benign_hit_outcome]
     
-    logger.info("Clear failed for %s (%s) as Benign RNA >%i bases unaccounted for, for %s",
-                    hit.name, hit.recommendation.status, MINIMUM_RNA_BASEPAIR_COVERAGE, query.name)
+    logger.info("Clear failed for %s (%s) as Benign RNA >%i bases unaccounted for.",
+                    hit.name, hit.recommendation.status, MINIMUM_RNA_BASEPAIR_COVERAGE)
     return []
 
 def _filter_benign_dna(query : Query,
@@ -177,7 +177,7 @@ def _filter_benign_dna(query : Query,
     # Filter benign SynBio for relevance...
     benign_dna_for_query_trimmed = _trim_to_region(benign_dna_for_query, region).copy()
     if benign_dna_for_query_trimmed.empty:
-        logger.debug("\t\t\tNo overlapping benign Synbio regions for %s (%i-%i)",
+        logger.debug("\t ... No overlapping benign DNA regions for %s (%i-%i)",
                      hit.name, region.query_start, region.query_end)
         return []
 
@@ -194,8 +194,8 @@ def _filter_benign_dna(query : Query,
                      benign_dna_for_query_trimmed.head())
 
     if benign_dna_for_query_trimmed.empty:
-        logger.info("\t --> Synbio sequences <80%% coverage achieved over hit %s over %i-%i for query %s.",
-                        hit.name, region.query_start, region.query_end, query.name)
+        logger.info("\t --> Synbio sequences <80%% coverage achieved over hit %s over %i-%i.",
+                        hit.name, region.query_start, region.query_end)
         return []
 
     benign_hit = benign_dna_for_query_trimmed["subject title"][0]
@@ -220,8 +220,8 @@ def _filter_benign_dna(query : Query,
     logger.debug("Processing Benign Hit: %s", benign_hit_outcome)
     
     if hit.recommendation.status not in {ScreenStatus.CLEARED_FLAG, ScreenStatus.CLEARED_WARN}:
-        logger.info("\t --> Clearing %s %s region %i-%i as Benign Nucleotide, for %s, with Synthetic Biology Part %s",
-                        hit.recommendation.status, hit.name, region.query_start, region.query_end, query.name, benign_hit_outcome.name)
+        logger.info("\t --> Clearing %s %s region %i-%i as Benign DNA, with synthetic biology part %s",
+                        hit.recommendation.status, hit.name, region.query_start, region.query_end, benign_hit_outcome.name)
         hit.recommendation.status = hit.recommendation.status.clear()
 
     return [benign_hit_outcome]
@@ -243,29 +243,29 @@ def _update_benign_data_for_query(query : Query,
     benign_rna_for_query = pd.DataFrame()
     benign_dna_for_query = pd.DataFrame()
 
-    # We only care about the benign data for this query.
+    logger.info(" Benign checks for %s", query.name)
+
+    # We only care about the benign data for this query, but we need to check for size.
     if not benign_protein.empty:
         benign_protein_for_query = benign_protein[
             benign_protein["query name"].str.rsplit("_", n=1).str[0] == query.name
         ]
-    else:
-        logger.info("\t\t...no housekeeping protein hits for %s", query.name)
 
     if not benign_rna.empty:
         benign_rna_for_query = benign_rna[
             benign_rna["query name"] == query.name
         ]
-    else:
-        logger.info("\t\t...no benign RNA hits for %s", query.name)
 
     if not benign_dna.empty:
         benign_dna_for_query = benign_dna[
             benign_dna["query acc."] == query.name
         ]
-    else:
-        logger.info("\t\t...no Synbio sequence hits for %s", query.name)
 
     new_benign_hits = []
+    # Separated for logging purposes only.
+    new_benign_protein_hits = []
+    new_benign_rna_hits = []
+    new_benign_dna_hits = []
 
     # Check every region, of every hit that is a FLAG or WARN, against the Benign screen outcomes.
     for hit in query.result_handle.hits.values():
@@ -283,23 +283,35 @@ def _update_benign_data_for_query(query : Query,
         for region in hit.ranges:
 
             if not benign_protein_for_query.empty:
-                new_benign_hits.extend(
+                new_benign_protein_hits.extend(
                     _filter_benign_proteins(query, hit, region,
                                             benign_protein_for_query,
                                             benign_descriptions)
                     )
             
             if not benign_rna_for_query.empty:
-                new_benign_hits.extend(
+                new_benign_rna_hits.extend(
                     _filter_benign_rna(query, hit, region,
                                        benign_rna_for_query)
                 )
                 
             if not benign_dna_for_query.empty:
-                new_benign_hits.extend(
+                new_benign_dna_hits.extend(
                     _filter_benign_dna(query, hit, region,
                                           benign_dna_for_query)
                     )
+                
+    # Report Query Specific lack of hits.
+    if len(new_benign_protein_hits) == 0:
+        logger.info("\t ... no housekeeping protein hits.")
+    if len(new_benign_rna_hits) == 0:
+        logger.info("\t ... no benign RNA hits.")
+    if len(new_benign_dna_hits) == 0:
+        logger.info("\t ... no benign DNA hits.")
+
+    new_benign_hits.extend(new_benign_protein_hits)
+    new_benign_hits.extend(new_benign_rna_hits)
+    new_benign_hits.extend(new_benign_dna_hits)
 
     logger.debug("\tNew benign hits added: %i", len(new_benign_hits))
     for benign_addition in new_benign_hits:

--- a/commec/screeners/check_biorisk.py
+++ b/commec/screeners/check_biorisk.py
@@ -162,7 +162,7 @@ def update_biorisk_data_from_database(search_handle : HmmerHandler,
 
             biorisk_overall = compare(target_recommendation, biorisk_overall)
 
-            regulation_str : str = "Regulated Gene" if must_flag else "Virulance Factor"
+            regulation_str : str = "Regulated Gene" if must_flag else "Virulence Factor"
 
             hit_data : HitResult = query_data.get_hit(affected_target)
             if hit_data:

--- a/commec/screeners/check_biorisk.py
+++ b/commec/screeners/check_biorisk.py
@@ -82,6 +82,9 @@ def update_biorisk_data_from_database(search_handle : HmmerHandler,
         logger.error("\t...ERROR: biorisk search results empty\n")
         return 1
 
+    # We delay non-debug logging to sort messages via query.
+    log_container = {key : [] for key in data.queries.keys()}
+
     for query in data.queries.values():
         query.recommendation.biorisk_status = ScreenStatus.PASS
 
@@ -162,14 +165,17 @@ def update_biorisk_data_from_database(search_handle : HmmerHandler,
 
             biorisk_overall = compare(target_recommendation, biorisk_overall)
 
+            # Precalculate some logging information...
             regulation_str : str = "Regulated Gene" if must_flag else "Virulence Factor"
+            log_message = f"\t --> {regulation_str} found at coordinates: {match_string}."
+            logger.debug(f"{affected_query[:-2]:<25}" + log_message)
+            log_container[affected_query[:-2]].append(log_message)
 
+            # Deal with whether this biorisk should collapse into an existing hit or not.
             hit_data : HitResult = query_data.get_hit(affected_target)
             if hit_data:
-                logger.debug("\t\tHit already exists! Extending hit data ranges only...")
+                logger.debug("\t\tHit already existed! Extending hit data ranges only...")
                 hit_data.ranges.extend(match_ranges)
-                logger.info("\t --> %s found in %s at coordinates: %s.",
-                    regulation_str, affected_query[:-2], match_string)
                 logger.debug("Updated hit: %s", hit_data)
                 continue
 
@@ -185,13 +191,21 @@ def update_biorisk_data_from_database(search_handle : HmmerHandler,
                 match_ranges,
                 {"domain" : [domain],"regulated":[regulation_str]},
             )
+            logger.debug("\t\tHit was unique, creating new hit result information...\n%s", new_hit)
             query_data.hits[affected_target] = new_hit
 
-            logger.debug("\t\tHit unique, creating new hit result information...\n%s", new_hit)
 
-            logger.info("\t --> %s found in %s at coordinates: %s.",
-                        regulation_str, affected_query[:-2], match_string)
 
         # Update the recommendation for this query for biorisk.
         query_data.recommendation.biorisk_status = biorisk_overall
+
+    # Do all non-verbose logging in order of query:
+    for query_name, log_list in log_container.items():
+        if len(log_list) == 0:
+            continue
+        s = "" if len(log_list) == 1 else "s"
+        logger.info(f" Biorisk{s} in {query_name}:")
+        for log_text in log_list:
+            logger.info(log_text)
+
     return 0

--- a/commec/screeners/check_reg_path.py
+++ b/commec/screeners/check_reg_path.py
@@ -283,7 +283,7 @@ def update_taxonomic_data_from_database(
                 alt_text = "only " if recommendation == ScreenStatus.FLAG else "both regulated and non-"
                 ## REGULATED:
                 logger.info(
-                        "\t --> %s %s contains match to %s at bases (%s) found in %sregulated organisms (%s). Regulated Species: %s Regulated TaxIDs: %s",
+                        "\t --> %s %s contains match to %s at bases (%s) found in %sregulated organisms (%s). (Regulated Species: %s. Regulated TaxID(s): %s)",
                         recommendation, query, hit, match_ranges_text, alt_text, domains_text, reg_species_text, reg_taxids_text
                     )
                     #logger.info(

--- a/commec/screeners/check_reg_path.py
+++ b/commec/screeners/check_reg_path.py
@@ -299,6 +299,7 @@ def update_taxonomic_data_from_database(
                         write_hit.annotations["domain"] = domains
                         write_hit.annotations["regulated_taxonomy"].append(regulation_dict)
                         write_hit.recommendation.status = compare(write_hit.recommendation.status, recommendation)
+                        write_hit.description += ","+hit_description
 
     # Do all non-verbose logging in order of query:
     for query_name, log_list in log_container.items():

--- a/commec/screeners/check_reg_path.py
+++ b/commec/screeners/check_reg_path.py
@@ -297,7 +297,7 @@ def update_taxonomic_data_from_database(
                     write_hit = query_write.get_hit(hit)
                     if write_hit:
                         write_hit.annotations["domain"] = domains
-                        write_hit.annotations["regulation"].append(regulation_dict)
+                        write_hit.annotations["regulated_taxonomy"].append(regulation_dict)
                         write_hit.recommendation.status = compare(write_hit.recommendation.status, recommendation)
 
     # Do all non-verbose logging in order of query:

--- a/commec/tests/test_data/functional.json
+++ b/commec/tests/test_data/functional.json
@@ -2,7 +2,7 @@
     "commec_info": {
         "commec_version": "0.3.2",
         "json_output_version": "0.1",
-        "time_taken": "00:00:01",
+        "time_taken": "00:00:02",
         "date_run": "",
         "search_tool_info": {
             "biorisk_search_info": {
@@ -32,7 +32,7 @@
         }
     },
     "query_info": {
-        "file": "/tmp/pytest-of-root/pytest-25/test_functional_screen0/functional.fasta",
+        "file": "/tmp/pytest-of-root/pytest-67/test_functional_screen0/functional.fasta",
         "number_of_queries": 1,
         "total_query_length": 600
     },
@@ -44,7 +44,7 @@
                 "screen_status": "Flag",
                 "biorisk_status": "Flag",
                 "protein_taxonomy_status": "Flag",
-                "nucleotide_taxonomy_status": "Error",
+                "nucleotide_taxonomy_status": "Flag",
                 "benign_status": "Flag"
             },
             "hits": {
@@ -130,12 +130,12 @@
                         ]
                     }
                 },
-                "NR_HIT_FLAG4": {
+                "        NR_HIT_FLAG4": {
                     "recommendation": {
                         "status": "Flag (Cleared)",
                         "from_step": "Protein Taxonomy Search"
                     },
-                    "name": "NR_HIT_FLAG4",
+                    "name": "        NR_HIT_FLAG4",
                     "description": "ShouldClear",
                     "ranges": [
                         {
@@ -168,12 +168,12 @@
                         ]
                     }
                 },
-                "NR_HIT_FLAG1": {
+                "    NR_HIT_FLAG1": {
                     "recommendation": {
                         "status": "Flag",
                         "from_step": "Protein Taxonomy Search"
                     },
-                    "name": "NR_HIT_FLAG1",
+                    "name": "    NR_HIT_FLAG1",
                     "description": "ShouldntClear",
                     "ranges": [
                         {
@@ -206,12 +206,12 @@
                         ]
                     }
                 },
-                "NR_HIT_MIXED": {
+                "    NR_HIT_MIXED": {
                     "recommendation": {
                         "status": "Pass",
                         "from_step": "Protein Taxonomy Search"
                     },
-                    "name": "NR_HIT_MIXED",
+                    "name": "    NR_HIT_MIXED",
                     "description": "ShouldMixedReg",
                     "ranges": [
                         {
@@ -285,12 +285,12 @@
                         ]
                     }
                 },
-                "NR_HIT_FLAG3": {
+                "    NR_HIT_FLAG3": {
                     "recommendation": {
                         "status": "Flag",
                         "from_step": "Protein Taxonomy Search"
                     },
-                    "name": "NR_HIT_FLAG3",
+                    "name": "    NR_HIT_FLAG3",
                     "description": "ShouldntClear",
                     "ranges": [
                         {
@@ -430,6 +430,46 @@
                                     "12345"
                                 ],
                                 "non_regulated_taxids": [],
+                                "regulated_species": [
+                                    "species"
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "NT_HIT_MIXED": {
+                    "recommendation": {
+                        "status": "Pass",
+                        "from_step": "Nucleotide Taxonomy Search"
+                    },
+                    "name": "NT_HIT_MIXED",
+                    "description": "Main",
+                    "ranges": [
+                        {
+                            "e_value": 0.0,
+                            "match_start": 1,
+                            "match_end": 100,
+                            "query_start": 501,
+                            "query_end": 581
+                        }
+                    ],
+                    "annotations": {
+                        "domain": [
+                            "Viruses"
+                        ],
+                        "regulated_taxonomy": [
+                            {
+                                "number_of_regulated_taxids": "1",
+                                "number_of_unregulated_taxids": "1",
+                                "regulated_eukaryotes": "0",
+                                "regulated_bacteria": "0",
+                                "regulated_viruses": "1",
+                                "regulated_taxids": [
+                                    "12345"
+                                ],
+                                "non_regulated_taxids": [
+                                    "12346"
+                                ],
                                 "regulated_species": [
                                     "species"
                                 ]

--- a/commec/tests/test_data/functional.json
+++ b/commec/tests/test_data/functional.json
@@ -1,7 +1,7 @@
 {
     "commec_info": {
         "commec_version": "0.3.2",
-        "json_output_version": "0.1",
+        "json_output_version": "0.2",
         "time_taken": "00:00:02",
         "date_run": "",
         "search_tool_info": {

--- a/commec/tests/test_data/functional.json
+++ b/commec/tests/test_data/functional.json
@@ -22,7 +22,7 @@
             "tool_info": "INFERNAL 1.1.5 (Sep 2023)",
             "database_info": "INFERNAL1/a [1.1.5 | Sep 2023]"
         },
-        "benign_synbio_database_info": {
+        "benign_dna_database_info": {
             "tool_info": "x.x.x",
             "database_info": "x.x.x"
         },
@@ -45,7 +45,7 @@
                 "Toxin1": {
                     "recommendation": {
                         "status": "Flag",
-                        "from_step": "Biorisk Screen"
+                        "from_step": "Biorisk Search"
                     },
                     "name": "Toxin1",
                     "description": " TestBioriskToxinFlag",
@@ -77,7 +77,7 @@
                 "Toxin2": {
                     "recommendation": {
                         "status": "Warning",
-                        "from_step": "Biorisk Screen"
+                        "from_step": "Biorisk Search"
                     },
                     "name": "Toxin2",
                     "description": " TestBioriskToxin",
@@ -102,7 +102,7 @@
                 "Toxin3": {
                     "recommendation": {
                         "status": "Warning",
-                        "from_step": "Biorisk Screen"
+                        "from_step": "Biorisk Search"
                     },
                     "name": "Toxin3",
                     "description": " TestBioriskToxin",
@@ -127,7 +127,7 @@
                 "NR_HIT_FLAG4": {
                     "recommendation": {
                         "status": "Flag (Cleared)",
-                        "from_step": "Protein Taxonomy Screen"
+                        "from_step": "Protein Taxonomy Search"
                     },
                     "name": "NR_HIT_FLAG4",
                     "description": "ShouldClear",
@@ -165,7 +165,7 @@
                 "NR_HIT_FLAG1": {
                     "recommendation": {
                         "status": "Flag",
-                        "from_step": "Protein Taxonomy Screen"
+                        "from_step": "Protein Taxonomy Search"
                     },
                     "name": "NR_HIT_FLAG1",
                     "description": "ShouldntClear",
@@ -203,7 +203,7 @@
                 "NR_HIT_MIXED": {
                     "recommendation": {
                         "status": "Pass",
-                        "from_step": "Protein Taxonomy Screen"
+                        "from_step": "Protein Taxonomy Search"
                     },
                     "name": "NR_HIT_MIXED",
                     "description": "ShouldMixedReg",
@@ -244,7 +244,7 @@
                 "NR_HIT_FLAG2": {
                     "recommendation": {
                         "status": "Flag (Cleared)",
-                        "from_step": "Protein Taxonomy Screen"
+                        "from_step": "Protein Taxonomy Search"
                     },
                     "name": "NR_HIT_FLAG2",
                     "description": "ShouldClearBySynbio",
@@ -282,7 +282,7 @@
                 "NR_HIT_FLAG3": {
                     "recommendation": {
                         "status": "Flag",
-                        "from_step": "Protein Taxonomy Screen"
+                        "from_step": "Protein Taxonomy Search"
                     },
                     "name": "NR_HIT_FLAG3",
                     "description": "ShouldntClear",
@@ -320,7 +320,7 @@
                 "NT_HIT_FLAG2": {
                     "recommendation": {
                         "status": "Flag (Cleared)",
-                        "from_step": "Nucleotide Taxonomy Screen"
+                        "from_step": "Nucleotide Taxonomy Search"
                     },
                     "name": "NT_HIT_FLAG2",
                     "description": "SUBJECT",
@@ -358,7 +358,7 @@
                 "NT_HIT_FLAG3": {
                     "recommendation": {
                         "status": "Flag",
-                        "from_step": "Nucleotide Taxonomy Screen"
+                        "from_step": "Nucleotide Taxonomy Search"
                     },
                     "name": "NT_HIT_FLAG3",
                     "description": "SUBJECT",
@@ -396,7 +396,7 @@
                 "NT_HIT_FLAG1": {
                     "recommendation": {
                         "status": "Flag (Cleared)",
-                        "from_step": "Nucleotide Taxonomy Screen"
+                        "from_step": "Nucleotide Taxonomy Search"
                     },
                     "name": "NT_HIT_FLAG1",
                     "description": "SUBJECT",
@@ -434,7 +434,7 @@
                 "Benign1": {
                     "recommendation": {
                         "status": "Pass",
-                        "from_step": "Benign Protein Screen"
+                        "from_step": "Benign Protein Search"
                     },
                     "name": "Benign1",
                     "description": "TEST_BENIGN_DESCRIPTION",
@@ -454,7 +454,7 @@
                 "BENIGNSYNBIO": {
                     "recommendation": {
                         "status": "Pass",
-                        "from_step": "Benign SynBio Screen"
+                        "from_step": "Benign DNA Search"
                     },
                     "name": "BENIGNSYNBIO",
                     "description": "BENIGNSYNBIO",
@@ -472,7 +472,7 @@
                 "BENIGNRNA": {
                     "recommendation": {
                         "status": "Pass",
-                        "from_step": "Benign RNA Screen"
+                        "from_step": "Benign RNA Search"
                     },
                     "name": "BENIGNRNA",
                     "description": "BenignCMTestOutput ",

--- a/commec/tests/test_data/functional.json
+++ b/commec/tests/test_data/functional.json
@@ -144,7 +144,7 @@
                         "domain": [
                             "Viruses"
                         ],
-                        "regulation": [
+                        "regulated_taxonomy": [
                             {
                                 "number_of_regulated_taxids": "1",
                                 "number_of_unregulated_taxids": "0",
@@ -182,7 +182,7 @@
                         "domain": [
                             "Viruses"
                         ],
-                        "regulation": [
+                        "regulated_taxonomy": [
                             {
                                 "number_of_regulated_taxids": "1",
                                 "number_of_unregulated_taxids": "0",
@@ -220,7 +220,7 @@
                         "domain": [
                             "Viruses"
                         ],
-                        "regulation": [
+                        "regulated_taxonomy": [
                             {
                                 "number_of_regulated_taxids": "1",
                                 "number_of_unregulated_taxids": "2",
@@ -261,7 +261,7 @@
                         "domain": [
                             "Viruses"
                         ],
-                        "regulation": [
+                        "regulated_taxonomy": [
                             {
                                 "number_of_regulated_taxids": "1",
                                 "number_of_unregulated_taxids": "0",
@@ -299,7 +299,7 @@
                         "domain": [
                             "Viruses"
                         ],
-                        "regulation": [
+                        "regulated_taxonomy": [
                             {
                                 "number_of_regulated_taxids": "1",
                                 "number_of_unregulated_taxids": "0",
@@ -337,7 +337,7 @@
                         "domain": [
                             "Viruses"
                         ],
-                        "regulation": [
+                        "regulated_taxonomy": [
                             {
                                 "number_of_regulated_taxids": "1",
                                 "number_of_unregulated_taxids": "0",
@@ -375,7 +375,7 @@
                         "domain": [
                             "Viruses"
                         ],
-                        "regulation": [
+                        "regulated_taxonomy": [
                             {
                                 "number_of_regulated_taxids": "1",
                                 "number_of_unregulated_taxids": "0",
@@ -413,7 +413,7 @@
                         "domain": [
                             "Viruses"
                         ],
-                        "regulation": [
+                        "regulated_taxonomy": [
                             {
                                 "number_of_regulated_taxids": "1",
                                 "number_of_unregulated_taxids": "0",

--- a/commec/tests/test_data/functional.json
+++ b/commec/tests/test_data/functional.json
@@ -2,38 +2,44 @@
     "commec_info": {
         "commec_version": "0.3.2",
         "json_output_version": "0.1",
-        "biorisk_database_info": {
-            "tool_info": "# HMMER 3.4 (Aug 2023); http://hmmer.org/",
-            "database_info": "HMMER3/f [3.4 | Aug 2023]"
-        },
-        "protein_database_info": {
-            "tool_info": "blastx: 2.16.0+\n Package: blast 2.16.0, build Dec 14 2024 23:05:40",
-            "database_info": "BLASTDB Version: 5Date: Sep 3, 2024  12:32 AM\tLongest sequence: 2,882 residues"
-        },
-        "nucleotide_database_info": {
-            "tool_info": "blastn: 2.16.0+\n Package: blast 2.16.0, build Dec 14 2024 23:05:40",
-            "database_info": "BLASTDB Version: 5Date: Sep 3, 2024  12:16 AM\tLongest sequence: 8,669 bases"
-        },
-        "benign_protein_database_info": {
-            "tool_info": "# HMMER 3.4 (Aug 2023); http://hmmer.org/",
-            "database_info": "HMMER3/f [3.4 | Aug 2023]"
-        },
-        "benign_rna_database_info": {
-            "tool_info": "INFERNAL 1.1.5 (Sep 2023)",
-            "database_info": "INFERNAL1/a [1.1.5 | Sep 2023]"
-        },
-        "benign_dna_database_info": {
-            "tool_info": "x.x.x",
-            "database_info": "x.x.x"
-        },
-        "time_taken": "00:00:00",
-        "date_run": "2025-03-26 23:33:43"
+        "time_taken": "00:00:01",
+        "date_run": "",
+        "search_tool_info": {
+            "biorisk_search_info": {
+                "tool_info": "# HMMER 3.4 (Aug 2023); http://hmmer.org/",
+                "database_info": "HMMER3/f [3.4 | Aug 2023]"
+            },
+            "protein_search_info": {
+                "tool_info": "blastx: 2.16.0+\n Package: blast 2.16.0, build Mar 28 2025 16:30:45",
+                "database_info": "BLASTDB Version: 5Date: Sep 3, 2024  12:32 AM\tLongest sequence: 2,882 residues"
+            },
+            "nucleotide_search_info": {
+                "tool_info": "blastn: 2.16.0+\n Package: blast 2.16.0, build Mar 28 2025 16:30:45",
+                "database_info": "BLASTDB Version: 5Date: Sep 3, 2024  12:16 AM\tLongest sequence: 8,669 bases"
+            },
+            "benign_protein_search_info": {
+                "tool_info": "# HMMER 3.4 (Aug 2023); http://hmmer.org/",
+                "database_info": "HMMER3/f [3.4 | Aug 2023]"
+            },
+            "benign_rna_search_info": {
+                "tool_info": "INFERNAL 1.1.5 (Sep 2023)",
+                "database_info": "INFERNAL1/a [1.1.5 | Sep 2023]"
+            },
+            "benign_dna_search_info": {
+                "tool_info": "x.x.x",
+                "database_info": "x.x.x"
+            }
+        }
+    },
+    "query_info": {
+        "file": "/tmp/pytest-of-root/pytest-25/test_functional_screen0/functional.fasta",
+        "number_of_queries": 1,
+        "total_query_length": 600
     },
     "queries": {
         "FCTEST1": {
             "query": "FCTEST1",
             "length": 600,
-            "sequence": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             "recommendation": {
                 "screen_status": "Flag",
                 "biorisk_status": "Flag",
@@ -451,24 +457,6 @@
                         "Coverage: ": 0.9833333333333333
                     }
                 },
-                "BENIGNSYNBIO": {
-                    "recommendation": {
-                        "status": "Pass",
-                        "from_step": "Benign DNA Search"
-                    },
-                    "name": "BENIGNSYNBIO",
-                    "description": "BENIGNSYNBIO",
-                    "ranges": [
-                        {
-                            "e_value": 0.0,
-                            "match_start": 10,
-                            "match_end": 100,
-                            "query_start": 410,
-                            "query_end": 480
-                        }
-                    ],
-                    "annotations": {}
-                },
                 "BENIGNRNA": {
                     "recommendation": {
                         "status": "Pass",
@@ -483,6 +471,24 @@
                             "match_end": 200,
                             "query_start": 50,
                             "query_end": 150
+                        }
+                    ],
+                    "annotations": {}
+                },
+                "BENIGNSYNBIO": {
+                    "recommendation": {
+                        "status": "Pass",
+                        "from_step": "Benign DNA Search"
+                    },
+                    "name": "BENIGNSYNBIO",
+                    "description": "BENIGNSYNBIO",
+                    "ranges": [
+                        {
+                            "e_value": 0.0,
+                            "match_start": 10,
+                            "match_end": 100,
+                            "query_start": 410,
+                            "query_end": 480
                         }
                     ],
                     "annotations": {}

--- a/commec/tests/test_data/functional.json
+++ b/commec/tests/test_data/functional.json
@@ -95,7 +95,7 @@
                             "not assigned"
                         ],
                         "regulated": [
-                            "Virulance Factor"
+                            "Virulence Factor"
                         ]
                     }
                 },
@@ -120,7 +120,7 @@
                             "not assigned"
                         ],
                         "regulated": [
-                            "Virulance Factor"
+                            "Virulence Factor"
                         ]
                     }
                 },

--- a/commec/tests/test_json.py
+++ b/commec/tests/test_json.py
@@ -23,12 +23,17 @@ def test_screendata():
                 benign_dna_search_info=SearchToolVersion("Blast 0.0.0","DB 0.0.0"),
             )
         ),
+        query_info = ScreenQueryInfo(
+            file="no file",
+            number_of_queries=1,
+            total_query_length=10
+        ),
         queries= {
             "Query1":
             QueryResult(
                 query="Query1",
                 length=10,
-                sequence="ABCDEFGHIJ",
+                #sequence="ABCDEFGHIJ",
                 recommendation = QueryScreenStatus(),
                 hits = {
                     "ImportantProtein1":
@@ -119,7 +124,7 @@ def test_adding_data_to_existing():
         input_query.recommendation.biorisk_status = ScreenStatus.PASS
     
     new_screen_data = ScreenResult()
-    new_screen_data.queries["test01"] = QueryResult("test01", 10, "ATGCATGCAT", ScreenStatus.FLAG)
+    new_screen_data.queries["test01"] = QueryResult("test01", 10, ScreenStatus.FLAG)
     write_query = new_screen_data.get_query("test01")
     write_info(write_query)
     assert new_screen_data.queries["test01"].recommendation.biorisk_status == ScreenStatus.PASS

--- a/commec/tests/test_json.py
+++ b/commec/tests/test_json.py
@@ -12,14 +12,16 @@ def test_screendata():
         commec_info = ScreenRunInfo(
             commec_version="0.1.2",
             json_output_version=JSON_COMMEC_FORMAT_VERSION,
-            biorisk_database_info=SearchToolVersion("HMM 0.0.0","DB 0.0.0"),
-            protein_database_info=SearchToolVersion("Blast 0.0.0","DB 0.0.0"),
-            nucleotide_database_info=SearchToolVersion("Blast 0.0.0","DB 0.0.0"),
-            benign_protein_database_info=SearchToolVersion("Blast 0.0.0","DB 0.0.0"),
-            benign_rna_database_info=SearchToolVersion("Blast 0.0.0","DB 0.0.0"),
-            benign_synbio_database_info=SearchToolVersion("Blast 0.0.0","DB 0.0.0"),
             time_taken="00:00:00:00",
             date_run="1.1.2024",
+            search_tool_info= SearchToolInfo(
+                biorisk_search_info=SearchToolVersion("HMM 0.0.0","DB 0.0.0"),
+                protein_search_info=SearchToolVersion("Blast 0.0.0","DB 0.0.0"),
+                nucleotide_search_info=SearchToolVersion("Blast 0.0.0","DB 0.0.0"),
+                benign_protein_search_info=SearchToolVersion("Blast 0.0.0","DB 0.0.0"),
+                benign_rna_search_info=SearchToolVersion("Blast 0.0.0","DB 0.0.0"),
+                benign_dna_search_info=SearchToolVersion("Blast 0.0.0","DB 0.0.0"),
+            )
         ),
         queries= {
             "Query1":

--- a/commec/tests/test_screen.py
+++ b/commec/tests/test_screen.py
@@ -197,6 +197,10 @@ def test_functional_screen(tmp_path, request):
     output_result.commec_info = None
     test_result.commec_info = None
 
+    # Pytest increments the filename version, so ignore the input file.
+    output_result.query_info.file = "REPLACED"
+    test_result.query_info.file = "REPLACED"
+
 
     # Convert both original and retrieved data to dictionaries and compare
     assert asdict(output_result) == asdict(test_result), (

--- a/commec/tests/test_screen.py
+++ b/commec/tests/test_screen.py
@@ -75,24 +75,24 @@ def test_functional_screen(tmp_path, request):
     )
     blastnr_to_parse = textwrap.dedent(
         """\
-        #query acc.	title	subject acc.taxid	evalue	bit score	% identity	    q.len	q.start	q.end	s.len	s. start	s. end
-        FCTEST1	ShouldntClear	NR_HIT_FLAG1	12345	    0.0	    BITSCORE	99.999	    500	    320	    380	    100	    1	        100
-        FCTEST1	ShouldClearBySynbio	NR_HIT_FLAG2	12345	    0.0	    BITSCORE	99.999	    500	    410	    490	    100	    1	        100
-        FCTEST1	ShouldntClear	NR_HIT_FLAG3	12345	    0.0	    BITSCORE	99.999	    500	    410	    500	    100	    1	        100
-        FCTEST1	ShouldClear	NR_HIT_FLAG4	12345	    0.0	    BITSCORE	99.999	    500	    310	    370	    100	    1	        100
-        FCTEST1	ShouldMixedReg	NR_HIT_MIXED	12345	    0.0	    BITSCORE	99.999	    500	    340	    390	    100	    1	        100
-        FCTEST1	ShouldMixednonReg	NR_HIT_MIXED	12346	    0.0	    BITSCORE	99.999	    500	    340	    390	    100	    1	        100
-        FCTEST1	ShouldMixedNonReg	NR_HIT_MIXED	12347	    0.0	    BITSCORE	99.999	    500	    340	    390	    100	    1	        100
+        #query acc.	title	        subject acc.taxid	evalue	bit score	% identity	    q.len	q.start	q.end	s.len	s. start	s. end
+        FCTEST1	ShouldntClear	    NR_HIT_FLAG1	12345	    0.0	    BITSCORE	99.999	    600	    320	    380	    100	    1	        100
+        FCTEST1	ShouldClearBySynbio	NR_HIT_FLAG2	12345	    0.0	    BITSCORE	99.999	    600	    410	    490	    100	    1	        100
+        FCTEST1	ShouldntClear	    NR_HIT_FLAG3	12345	    0.0	    BITSCORE	99.999	    600	    410	    500	    100	    1	        100
+        FCTEST1	ShouldClear	        NR_HIT_FLAG4	12345	    0.0	    BITSCORE	99.999	    600	    310	    370	    100	    1	        100
+        FCTEST1	ShouldMixedReg	    NR_HIT_MIXED	12345	    0.0	    BITSCORE	99.999	    600	    340	    390	    100	    1	        100
+        FCTEST1	ShouldMixednonReg	NR_HIT_MIXED	12346	    0.0	    BITSCORE	99.999	    600	    340	    390	    100	    1	        100
+        FCTEST1	ShouldMixedNonReg	NR_HIT_MIXED	12347	    0.0	    BITSCORE	99.999	    600	    340	    390	    100	    1	        100
         """
     )
     blastnt_to_parse = textwrap.dedent(
         """\
         #query acc.	title	subject acc.taxid	evalue	bit score	% identity	    q.len	q.start 	q.end	s.len	s. start	s. end
-        FCTEST1	SUBJECT	NT_HIT_FLAG1	    12345	    0.0	    BITSCORE	99.999	    500	    220	    280	     60	    1	        100
-        FCTEST1	SUBJECT	NT_HIT_FLAG2	    12345	    0.0	    BITSCORE	99.999	    500	    110	    190	     80	    1	        100
-        FCTEST1	SUBJECT	NT_HIT_FLAG3	    12345	    0.0	    BITSCORE	99.999	    500	    110	    200	     90	    1	        100
-        FCTEST1	SUBJECT	NT_HIT_MIXED	12345	    0.0	    BITSCORE	99.999	    500	    350	    410	    100	    1	        100
-        FCTEST1	SUBJECT	NT_HIT_MIXED	12346	    0.0	    BITSCORE	99.999	    500	    350	    410	    100	    1	        100
+        FCTEST1	SUBJECT	NT_HIT_FLAG1	    12345	    0.0	    BITSCORE	99.999	    600	    220	    280	     60	    1	        100
+        FCTEST1	SUBJECT	NT_HIT_FLAG2	    12345	    0.0	    BITSCORE	99.999	    600	    110	    190	     80	    1	        100
+        FCTEST1	SUBJECT	NT_HIT_FLAG3	    12345	    0.0	    BITSCORE	99.999	    600	    110	    200	     90	    1	        100
+        FCTEST1	Main	NT_HIT_MIXED	    12345	    0.0	    BITSCORE	99.999	    600	    310	    390	    100	    1	        100
+        FCTEST1	NonRegMixedWithMain	NT_HIT_MIXED2	    12346	    0.0	    BITSCORE	99.999	    600	    310	    390	    100	    1	        100
         """
     )
 

--- a/commec/tools/fetch_nc_bits.py
+++ b/commec/tools/fetch_nc_bits.py
@@ -177,6 +177,8 @@ def calculate_noncoding_regions_per_query(
     for query in queries.values():
         #record = query.seq_record
         protein_matches_for_query = protein_matches[protein_matches[query_col] == query.name]
+        # Overriding query length in nc record.
+        protein_matches_for_query.loc[:, "q.len"] = len(query.seq_record.seq)
 
         if protein_matches_for_query.empty:
             logger.info("No protein hits found for %s, screening entire sequence.", query.name)

--- a/commec/tools/fetch_nc_bits.py
+++ b/commec/tools/fetch_nc_bits.py
@@ -175,15 +175,15 @@ def calculate_noncoding_regions_per_query(
     query_col = "query acc."
 
     for query in queries.values():
-        #record = query.seq_record
-        protein_matches_for_query = protein_matches[protein_matches[query_col] == query.name]
-        # Overriding query length in nc record.
-        protein_matches_for_query.loc[:, "q.len"] = len(query.seq_record.seq)
+        protein_matches_for_query = protein_matches[protein_matches[query_col] == query.name].copy()
 
         if protein_matches_for_query.empty:
             logger.info("No protein hits found for %s, screening entire sequence.", query.name)
             _set_no_coding_regions(query)
             continue
+
+        # Correcting query length in nc coordinate output.
+        protein_matches_for_query.loc[:, "q.len"] = len(query.seq_record.seq)
 
         logger.debug("\t --> Protein hits found for %s, fetching nt regions not covered by a 90%% ID hit or better", query.name)
 

--- a/commec/utils/json_html_output.py
+++ b/commec/utils/json_html_output.py
@@ -76,10 +76,15 @@ def generate_html_from_screen_data(input_data : ScreenResult, output_file : str)
         html = fig.to_html(file_name, full_html = False, include_plotlyjs='cdn')
         figures_html.append(html)
 
+    # Additional template information
+    n_query = input_data.query_info.number_of_queries
+    plural = "y" if n_query == 1 else "ies"
+    html_title = f"Commec Screen Summary: {n_query} Quer{plural}."
+
     # Construct the composite HTML
     template_path = str(importlib.resources.files("commec").joinpath("utils").joinpath("template.html"))
     template = Template(filename = template_path)
-    rendered_html = template.render(figures_html=figures_html)
+    rendered_html = template.render(figures_html=figures_html, page_title=html_title)
 
     # Save the combined HTML output
     output_filename = output_file.strip()+".html"

--- a/commec/utils/json_html_output.py
+++ b/commec/utils/json_html_output.py
@@ -50,7 +50,7 @@ def color_from_hit(hit : HitResult) -> CommecPalette:
         return CommecPalette.RED
     if (hit.recommendation.from_step == ScreenStep.BENIGN_PROTEIN or
         hit.recommendation.from_step == ScreenStep.BENIGN_RNA or
-        hit.recommendation.from_step == ScreenStep.BENIGN_SYNBIO):
+        hit.recommendation.from_step == ScreenStep.BENIGN_DNA):
         return CommecPalette.LT_BLUE
     if hit.recommendation.from_step == ScreenStep.TAXONOMY_AA:
         return CommecPalette.ORANGE

--- a/commec/utils/json_html_output.py
+++ b/commec/utils/json_html_output.py
@@ -152,8 +152,8 @@ def generate_outcome_string(query : QueryResult, hit : HitResult) -> str:
         non_regulated_taxids = []
         regulated_species = []
 
-        if "regulation" in hit.annotations:
-            reg = hit.annotations["regulation"]
+        if "regulated_taxonomy" in hit.annotations:
+            reg = hit.annotations["regulated_taxonomy"]
             for r in reg:
                 n_regulated_eukaryotes += int(r["regulated_eukaryotes"])
                 n_regulated_bacteria += int(r["regulated_bacteria"])

--- a/commec/utils/template.html
+++ b/commec/utils/template.html
@@ -14,7 +14,7 @@
             display: flex;
             flex-direction: column; /* Changed to column to stack figures vertically */
             height: 100vh;
-            width: 80vw;
+            width: 100vw;
             margin: 0 auto;
             overflow: auto; /* Enable scrolling for the container */
         }

--- a/commec/utils/template.html
+++ b/commec/utils/template.html
@@ -14,6 +14,8 @@
             display: flex;
             flex-direction: column; /* Changed to column to stack figures vertically */
             height: 100vh;
+            width: 80vw;
+            margin: 0 auto;
             overflow: auto; /* Enable scrolling for the container */
         }
 

--- a/commec/utils/template.html
+++ b/commec/utils/template.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Interactive Plotly Figures</title>
+    <title>${page_title | h}</title>
     <style>
         body {
             margin: 0;


### PR DESCRIPTION
## Background
After the great rebase of JSON and HTML functionality into develop, this PR addresses a first round of feedback with several fixes.

## Changes
* fixed typos of Virulence.
* Updated non-verbose logging to be more consistent across steps, and at a per query level.
* All databases/search/screen are consistently referenced as Search, both in outputs and internally.
** (The only Screen reference is to the Commec Screen itself, a Commec Screen can be thought of being composed of many Searches)
* Additional regulation annotations now referred to as regulated_taxonomy in taxonomy searches.
* JSON output now includes a small query_info section, containing an abs path to the original fasta file. Query number, and total length in bps of all queries.
* JSON query no longer stores the full sequence information.
* HTML page now has custom heading functionality for the tab.
* Beautified the HTML outputs.
* Taxonomy hits which share exactly the same region coordinates on the query now share a hit, and update their information. Leading to better collapsing of overly verbose outputs.

### Bug fixes
* Important bug fix to query name key generation to avoid issues with translation truncated names with the | character.
* Skip is no longer used as a potential benign state to override overall recommendation.
* Fixed an issue where the incorrect query length was being used to calculate the final non-coding region. Updated functional test to no longer unexpectedly fail for nucleotide due to this.

## Relevant logs, error messages, etc.
* Debug --verbose mode now prints all the names, and original names for all queries.