### PR TITLE
Add --version, -v to commec cli.

### DIFF
--- a/commec/__init__.py
+++ b/commec/__init__.py
@@ -1,0 +1,5 @@
+from importlib.metadata import version
+try:
+    __version__ = version(__name__)
+except:
+    __version__ = "X.X.X"

--- a/commec/__init__.py
+++ b/commec/__init__.py
@@ -1,5 +1,5 @@
-from importlib.metadata import version
+from importlib.metadata import version, PackageNotFoundError
 try:
-    __version__ = version(__name__)
-except:
+    __version__ = version("commec")
+except ImportError, PackageNotFoundError:
     __version__ = "X.X.X"

--- a/commec/cli.py
+++ b/commec/cli.py
@@ -52,7 +52,7 @@ def main():
         dest="version",
         action="store_true",
         default=False,
-        help="Print version information and exit.",
+        help="show version information and exit",
     )
 
     # Setup sub parsers:

--- a/commec/cli.py
+++ b/commec/cli.py
@@ -37,7 +37,7 @@ from commec.setup import (
     run as setup_run,
 )
 
-from commec.config.result import COMMEC_VERSION
+from commec import __version__ as COMMEC_VERSION
 
 def main():
     """

--- a/commec/cli.py
+++ b/commec/cli.py
@@ -12,7 +12,8 @@ Command-line usage:
     - commec screen -d /path/to/databases input.fasta
     - commec flag /path/to/directory/with/output.screen 
     - commec split input.fasta
-    - commec version
+    - commec -h, --help
+    - commec -v, --version
 """
 from commec.flag import (
     DESCRIPTION as flag_DESCRIPTION,

--- a/commec/cli.py
+++ b/commec/cli.py
@@ -12,6 +12,7 @@ Command-line usage:
     - commec screen -d /path/to/databases input.fasta
     - commec flag /path/to/directory/with/output.screen 
     - commec split input.fasta
+    - commec version
 """
 from commec.flag import (
     DESCRIPTION as flag_DESCRIPTION,
@@ -35,6 +36,8 @@ from commec.setup import (
     run as setup_run,
 )
 
+from commec.config.result import COMMEC_VERSION
+
 def main():
     """
     Parse the command line arguments and call the relevant sub-command.
@@ -42,6 +45,17 @@ def main():
     parser = ScreenArgumentParser(
         prog="commec", description="Command-line entrypoint for the Common Mechanism"
     )
+    # Sub argument for version information
+    parser.add_argument(
+        "-v",
+        "--version",
+        dest="version",
+        action="store_true",
+        default=False,
+        help="Print version information and exit.",
+    )
+
+    # Setup sub parsers:
     subparsers = parser.add_subparsers(dest="command")
 
     # Sub-command for "screen"
@@ -70,6 +84,11 @@ def main():
         split_run(args)
     elif args.command == "setup":
         setup_run(args)
+    elif args.version:
+        print( "Commec  : The Common Mechanism\n"
+              f"Version : {COMMEC_VERSION}\n"
+              "Copyright IBBIS (c) 2021-2025\n"
+              "International Biosecurity and Biosafety Initiative for Science")
     else:
         parser.print_help()
 

--- a/commec/config/result.py
+++ b/commec/config/result.py
@@ -34,13 +34,11 @@ from enum import StrEnum
 from importlib.metadata import version, PackageNotFoundError
 import pandas as pd
 from commec.tools.search_handler import SearchToolVersion
+from commec import __version__ as COMMEC_VERSION
 
 logger = logging.getLogger(__name__)
 
-try:
-    COMMEC_VERSION = version("commec")
-except PackageNotFoundError:
-    COMMEC_VERSION = "error"
+
 
 # Seperate versioning for the output JSON.
 JSON_COMMEC_FORMAT_VERSION = "0.2"


### PR DESCRIPTION
Simple adds in the ability to print the current Commec Version being used.

Example output terminal text:

```
Commec  : The Common Mechanism
Version : 0.3.2
Copyright IBBIS (c) 2021-2025
International Biosecurity and Biosafety Initiative for Science
```
