### PR TITLE
Reject querys below minimum length

### DIFF
--- a/commec/config/constants.py
+++ b/commec/config/constants.py
@@ -2,3 +2,6 @@
 # Copyright (c) 2021-2024 International Biosecurity and Biosafety Initiative for Science
 
 DEFAULT_CONFIG_YAML_PATH = "screen-default-config.yaml"
+
+# The minimum query length in nucleotides.
+MINIMUM_QUERY_LENGTH_NT = 40 # Queries smaller than this are ignored.

--- a/commec/config/query.py
+++ b/commec/config/query.py
@@ -22,7 +22,8 @@ class Query:
         self.non_coding_regions : list[tuple[int, int]] = [] # 1 based coordinates for Non-Coding Regions.
         self.result_handle : QueryResult = None
 
-    def translate(self, input_path, output_path) -> None:
+    @staticmethod
+    def translate(input_path, output_path) -> None:
         """Run command transeq, to translate our input sequences."""
 
         # TODO: Update line 53-55 of Check_Benign, to ensure that the query filter is using

--- a/commec/config/result.py
+++ b/commec/config/result.py
@@ -253,6 +253,12 @@ class QueryScreenStatus:
         Parses the query status across all screening steps, then updates overall flag.
         Designed to be called at any time after Step 1.
         """
+
+        # If we skipped biorisk, then we skipped Screen, and we can garuntee
+        # that we have already set this query's skipped result.
+        if self.biorisk_status == ScreenStatus.SKIP:
+            return
+
         if ScreenStatus.ERROR in {
             self.biorisk_status,
             self.protein_taxonomy_status,

--- a/commec/config/screen_io.py
+++ b/commec/config/screen_io.py
@@ -106,9 +106,6 @@ class ScreenIO:
             raise IoValidationError(f"Input FASTA file: {self.input_fasta_path} "
                                     "is not a valid fasta file.") from e
 
-        # Trim the input records according to Commec Criteria.
-        records = [record for record in records if ScreenIO.is_valid_record(record)]
-
         if len(records) == 0:
             raise IoValidationError(f"Input FASTA file: {self.input_fasta_path} "
                                     " contains no records!")
@@ -125,6 +122,9 @@ class ScreenIO:
                 record.description = ""
             except Exception as e:
                 raise IoValidationError(f"Failed to parse input fasta: {self.nt_path}") from e
+
+        # Trim the input records according to Commec Criteria.
+        records = [record for record in records if ScreenIO.is_valid_record(record)]
 
         with open(self.nt_path, "w", encoding = "utf-8") as fasta_file:
             SeqIO.write(records, fasta_file, "fasta")

--- a/commec/screeners/check_benign.py
+++ b/commec/screeners/check_benign.py
@@ -345,6 +345,8 @@ def update_benign_data_from_database(benign_protein_handle : HmmerHandler,
                 benign_dna_screen_data.shape, benign_dna_screen_data.head())
     
     for query in queries.values():
+        if query.result_handle.recommendation.benign_status == ScreenStatus.SKIP:
+            continue
         _update_benign_data_for_query(query,
                                       benign_protein_screen_data,
                                       benign_rna_screen_data,

--- a/commec/screeners/check_biorisk.py
+++ b/commec/screeners/check_biorisk.py
@@ -86,7 +86,8 @@ def update_biorisk_data_from_database(search_handle : HmmerHandler,
     log_container = {key : [] for key in data.queries.keys()}
 
     for query in data.queries.values():
-        query.recommendation.biorisk_status = ScreenStatus.PASS
+        if query.recommendation.biorisk_status != ScreenStatus.SKIP:
+            query.recommendation.biorisk_status = ScreenStatus.PASS
 
     if not search_handle.has_hits(search_handle.out_file):
         return 0

--- a/commec/screeners/check_reg_path.py
+++ b/commec/screeners/check_reg_path.py
@@ -95,6 +95,7 @@ def update_taxonomic_data_from_database(
 
     # The default is to pass, its up to the data to over-write this.
     # Some Queries may already be set to skip, which we ignore.
+    # (Only queries with no information from database would be skipped)
     if step == ScreenStep.TAXONOMY_AA:
         for query in data.queries.values():
             if query.recommendation.protein_taxonomy_status != ScreenStatus.SKIP:


### PR DESCRIPTION
## Background
Short sequences are a thorn in screenings sensitivity side. It is best to ensure we have a hard line in the sand on a minimum viable sequence size below which Commec Screen should simply not be used.

## Changes
Any sequences which are less than the constant, currently set to 40 nucleotides, are rejected at the import fasta phase. A warning is given to the user about any rejected sequences. Commec will still try to run if other sequences were valid.

## Refactors
To note, the function `is_valid_record` of query validation is statically part of ScreenIO, and could be used to include any future validation we want to have on Query SeqRecord objects.