### PR TITLE
Emboss removal

### DIFF
--- a/commec/config/query.py
+++ b/commec/config/query.py
@@ -2,6 +2,8 @@
 # Copyright (c) 2021-2025 International Biosecurity and Biosafety Initiative for Science
 
 import subprocess
+import os
+from Bio import Seq
 from Bio.SeqRecord import SeqRecord
 from dataclasses import dataclass
 from commec.config.result import QueryResult
@@ -35,17 +37,71 @@ class Query:
     def sequence(self) -> str:
         return str(self._seq_record.seq)
 
-    def translate(self, input_path, output_path) -> None:
-        """Run command transeq, to translate our input sequences."""
+    def translate(self, output_path: str | os.PathLike) -> None:
+        """
+        Append the six-frame translation of the query to the output file.
+        """
+        self._translate()
+        with open(output_path, "a", encoding="utf-8") as outfile:
+            for translation in self.translations:
+                outfile.write(f">{self.name}_{translation.frame}\n")
+                outfile.write(f"{translation.sequence}\n")
 
-        # TODO: Update line 53-55 of Check_Benign, to ensure that the query filter is using
-        # The correct name, when filtering benign components.
-        command = ["transeq", input_path, output_path, "-frame", "6", "-clean"]
-        result = subprocess.run(command, check = False, capture_output=True)
-        if result.returncode != 0:
-            raise RuntimeError(
-                f"Input FASTA {input_path} could not be translated:\n{result.stderr}"
+    def _translate(self) -> None:
+        """
+        Get the six-frame translations of the query sequence in all 6 reading frames.
+
+        Frame numbers follow the same naming convention as transeq:
+            * 1, 2, 3: Forward frames starting at positions 0, 1, 2
+            * 4, 5, 6: Reverse frames, starting at positions 0, -1, -2
+
+        Offsets are a little complicated. Taking the 11-nt sequence 'atgtgccatgg' as an example:
+
+            Frame   Pos     Codon split         Translation
+            1       0       atg tgc cat gg      MCH
+            2       1       a tgt gcc atg g     CAM
+            3       2       at gtg cca tgg      VPW
+            4       -0      cc atg gca cat      MAH
+            5       -1      c cat ggc aca t     HGT
+            6       -2      cca tgg cac at      PWH
+
+        As in previous `transeq -clean` command, all stop codons (*) are replaced with (X).
+
+        One *difference* from transeq is that we only translate full codons. So the frame 1 in the
+        example above is translated as MCH, rather than MCHG, even though gg will translate to
+        glycine (G) no matter what the subsequent nucleotide is.
+        """
+        self.translations = []
+        seq_rev = Seq.reverse_complement(self.sequence)
+
+        # Frames use offset 0, 1, 2
+        for offset in range(3):
+            frame_len = self._get_frame_length(offset)
+
+            # Forward frame is offset from the start of the sequence
+            f_start = offset
+            f_end = offset + frame_len
+            protein = str(Seq.translate(self.sequence[f_start:f_end], stop_symbol="X"))
+            self.translations.append(
+                QueryTranslation(sequence=protein, frame=offset + 1)
             )
+            # Reverse frame is offset from the end of the sequence
+            r_start = self.length - offset - frame_len
+            r_end = self.length - offset
+            protein = str(Seq.translate(seq_rev[r_start:r_end], stop_symbol="X"))
+            self.translations.append(
+                QueryTranslation(sequence=protein, frame=offset + 4)
+            )
+
+        # Sort the list in frame order
+        self.translations = sorted(self.translations, key=lambda x: x.frame)
+
+    def _get_frame_length(self, frame_offset: int) -> int:
+        """
+        Get total length of nt sequence that will be translated based on frame offset.
+        """
+        # Use integer division to get frame length based on starting offset
+        return 3 * ((self.length - frame_offset) // 3)
 
     @staticmethod
     def validate_sequence_record(seq_record: SeqRecord) -> None:

--- a/commec/screen.py
+++ b/commec/screen.py
@@ -301,7 +301,7 @@ class Screen:
         try:
             for query in self.queries.values():
                 logger.debug("Processing query: %s, (%s)", query.name, query.original_name)
-                query.translate(self.params.nt_path, self.params.aa_path)
+                query.translate(self.params.aa_path)
                 total_query_length += query.length
                 qr = QueryResult(query.original_name,query.length)
                 self.screen_data.queries[query.name] = qr

--- a/commec/screen.py
+++ b/commec/screen.py
@@ -302,10 +302,8 @@ class Screen:
             for query in self.queries.values():
                 logger.debug("Processing query: %s, (%s)", query.name, query.original_name)
                 query.translate(self.params.nt_path, self.params.aa_path)
-                total_query_length += len(query.seq_record)
-                qr = QueryResult(query.original_name,
-                                    len(query.seq_record))
-                                    #str(query.seq_record.seq))
+                total_query_length += query.length
+                qr = QueryResult(query.original_name,query.length)
                 self.screen_data.queries[query.name] = qr
                 query.result_handle = qr
         except RuntimeError as e:

--- a/commec/tests/test_query.py
+++ b/commec/tests/test_query.py
@@ -1,0 +1,152 @@
+from io import StringIO
+import os
+import pandas as pd
+import pytest
+import textwrap
+from Bio.Seq import Seq
+from Bio.SeqRecord import SeqRecord
+from commec.config.query import Query, QueryTranslation
+
+INPUT_QUERY = os.path.join(os.path.dirname(__file__), "test_data/single_record.fasta")
+
+def test_get_frame_length():
+    # 11 nt query
+    query = Query(SeqRecord(Seq("atgtgccatgg"), id="test"))
+    assert 9 == query._get_frame_length(frame_offset=0)
+    assert 9 == query._get_frame_length(frame_offset=1)
+    assert 9 == query._get_frame_length(frame_offset=2)
+
+    # 15 nt query
+    query = Query(SeqRecord(Seq("atgtgccatggatgc"), id="test"))
+    assert 15 == query._get_frame_length(frame_offset=0)
+    assert 12 == query._get_frame_length(frame_offset=1)
+    assert 12 == query._get_frame_length(frame_offset=2)
+
+    # 16 nt query
+    query = Query(SeqRecord(Seq("atgtgccatggatgca"), id="test"))
+    assert 15 == query._get_frame_length(frame_offset=0)
+    assert 15 == query._get_frame_length(frame_offset=1)
+    assert 12 == query._get_frame_length(frame_offset=2)
+
+def test_translate_to_file(tmp_path):
+    query = Query(SeqRecord(Seq("atgtgccatgg"), id="test"))
+
+    expected_output = textwrap.dedent(
+        """\
+        >test_1
+        MCH
+        >test_2
+        CAM
+        >test_3
+        VPW
+        >test_4
+        MAH
+        >test_5
+        HGT
+        >test_6
+        PWH
+        """
+    )
+
+    aa_output = tmp_path / "test_translated.faa"
+
+    query.translate(aa_output)
+
+    # Check if the output file exists
+    assert aa_output.exists()
+
+    actual_output = aa_output.read_text()
+    assert expected_output.strip() == actual_output.strip()
+
+
+def test_translate():
+    """
+    Test translation from nucleotide to 6 frames of protein sequences.
+    """
+    # 11nt query
+    query = Query(SeqRecord(Seq("atgtgccatgg"), id="test"))
+
+    # Input sequence: atgtgccatgg
+    # Translations:
+    # Frame   Pos     Codon split         Translation
+    # 1       0       atg tgc cat gg      MCH
+    # 2       1       a tgt gcc atg g     CAM
+    # 3       2       at gtg cca tgg      VPW
+    # 4       -0      cc atg gca cat      MAH
+    # 5       -1      c cat ggc aca t     HGT
+    # 6       -2      cca tgg cac at      PWH
+    expected_translations = [
+        QueryTranslation(frame=1, sequence="MCH"),
+        QueryTranslation(frame=2, sequence="CAM"),
+        QueryTranslation(frame=3, sequence="VPW"),
+        QueryTranslation(frame=4, sequence="MAH"),
+        QueryTranslation(frame=5, sequence="HGT"),
+        QueryTranslation(frame=6, sequence="PWH"),
+    ]
+
+    query._translate()
+    assert expected_translations == query.translations
+
+    # 15nt query
+    query = Query(SeqRecord(Seq("acgcacctgatcgct"), id="test"))
+
+
+    # Input sequence: acgcacctgatcgct
+    # Translations:
+    # Frame   Pos     Codon split              Translation
+    # 1       0       acg cac ctg atc gct      THLIA
+    # 2       1       a cgc acc tga tcg ct     RTXS
+    # 3       2       ac gca cct gat cgc t      APDR
+    # 4       -0      agc gat cag gtg cgt      SDQVR
+    # 5       -1      a gcg atc agg tgc gt     RSGA
+    # 6       -2      ag cga tca ggt gcg t     AIRC
+    expected_translations = [
+        QueryTranslation(frame=1, sequence="THLIA"),
+        QueryTranslation(frame=2, sequence="RTXS"),
+        QueryTranslation(frame=3, sequence="APDR"),
+        QueryTranslation(frame=4, sequence="SDQVR"),
+        QueryTranslation(frame=5, sequence="RSGA"),
+        QueryTranslation(frame=6, sequence="AIRC"),
+    ]
+
+    query._translate()
+    assert expected_translations == query.translations
+
+
+def test_ambigious():
+    """
+    Test translation from nucleotide to 6 frames of protein sequences using ambigious nts
+    | --------------------------------------------------------------------- |
+    | Code             | Bases Represented | Meaning                        |
+    | ---------------- | ----------------- | ------------------------------ |
+    | **A**            | A                 | Adenine                        |
+    | **C**            | C                 | Cytosine                       |
+    | **G**            | G                 | Guanine                        |
+    | **T** (or **U**) | T (or U in RNA)   | Thymine (or Uracil)            |
+    | **R**            | A or G            | puRine                         |
+    | **Y**            | C or T            | pYrimidine                     |
+    | **S**            | G or C            | Strong interaction (3 H-bonds) |
+    | **W**            | A or T            | Weak interaction (2 H-bonds)   |
+    | **K**            | G or T            | Keto                           |
+    | **M**            | A or C            | aMino                          |
+    | **B**            | C or G or T       | not A                          |
+    | **D**            | A or G or T       | not C                          |
+    | **H**            | A or C or T       | not G                          |
+    | **V**            | A or C or G       | not T                          |
+    | **N**            | A or C or G or T  | any base (completely unknown)  |
+    | --------------------------------------------------------------------- |
+    """
+    # 11nt query
+    #query = Query(SeqRecord(Seq("atntnccatgg"), id="test"))
+    query = Query(SeqRecord(Seq("ATGAARTAYGCNAAYGARACNABGGADCAHGAVACNTGG"), id="test"))
+    expected_translations = [
+        QueryTranslation(frame=1, sequence="MKYANETXXXXTW"),
+        QueryTranslation(frame=2, sequence="XXXXXXXXXXXX"),
+        QueryTranslation(frame=3, sequence="EXXXXBXGXXXX"),
+        QueryTranslation(frame=4, sequence="PXXXXXXXXXXXH"),
+        QueryTranslation(frame=5, sequence="XXXXPXXXXXXS"),
+        QueryTranslation(frame=6, sequence="XVSXSXVSXAYF"),
+    ]
+
+    query._translate()
+    assert expected_translations == query.translations, query.translations

--- a/commec/tools/fetch_nc_bits.py
+++ b/commec/tools/fetch_nc_bits.py
@@ -149,7 +149,7 @@ def fetch_noncoding_regions(protein_results, query_fasta):
     _write_nc_sequences(ranges_to_screen, records[0], outfile)
 
 def _set_no_coding_regions(query : Query):
-    query.non_coding_regions.append((1, len(query.seq_record.seq)))
+    query.non_coding_regions.append((1, query.length))
 
 def calculate_noncoding_regions_per_query(
         protein_results : str,
@@ -183,7 +183,7 @@ def calculate_noncoding_regions_per_query(
             continue
 
         # Correcting query length in nc coordinate output.
-        protein_matches_for_query.loc[:, "q.len"] = len(query.seq_record.seq)
+        protein_matches_for_query.loc[:, "q.len"] = query.length
 
         logger.debug("\t --> Protein hits found for %s, fetching nt regions not covered by a 90%% ID hit or better", query.name)
 

--- a/commec/tools/hmmer.py
+++ b/commec/tools/hmmer.py
@@ -191,4 +191,4 @@ def append_nt_querylength_info(hmmer : pd.DataFrame, queries : dict[str, Query])
     Take the hmmer output, and add a series (nt_qlen) 
     of the true nt length based on query name.
     """
-    hmmer["nt_qlen"] = [len(queries[q[:-2]].seq_record.seq) for q in hmmer["query name"]]
+    hmmer["nt_qlen"] = [queries[q[:-2]].length for q in hmmer["query name"]]

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -37,7 +37,6 @@ requirements:
     - pyyaml
     # Runtime non-Python dependencies
     - blast >=2.16
-    - emboss
     - diamond >=2.1
     - hmmer
     - infernal

--- a/environment.yaml
+++ b/environment.yaml
@@ -14,7 +14,6 @@ dependencies:
   # Runtime non-Python dependencies
   - blast
   - diamond>=2.1
-  - emboss
   - hmmer
   - infernal
   - plotly


### PR DESCRIPTION
## Background
Recreation of #31, which is a little old compared to the latest develop features which also had significant crossover with all #31 features and changes, and also incorporates some additional refactor complications.

The  `biocontainer` auto-built from the `commec` bioconda packages [currently has some gnarly security warnings](https://quay.io/repository/biocontainers/commec) (related to https://github.com/bioconda/bioconda-recipes/issues/46980#issuecomment-2604135864 ). This removes that dependency by writing our own `translate` method.

Also updates #26 (I have marked this as a draft, since that one should be merged first) to handle the fact that the precise indices of 6-frame translations depend on the length of the original nucleotide sequence, which may not be a multiple of three (as assumed in that PR).

**Issues**:
* Relates to https://github.com/ibbis-bio/common-mechanism/issues/28

## Changes

### Bug fixes
* No longer dependent on `transeq` from emboss, which means that biocontainer should have no warnings

### New features
* The `Query` class now translates itself in six frames