### PR TITLE
Adds additional debug output to record input CLI and parameters used in screen.

### DIFF
--- a/commec/config/screen_io.py
+++ b/commec/config/screen_io.py
@@ -12,6 +12,7 @@ import argparse
 import logging
 import multiprocessing
 import importlib.resources
+from pprint import pformat
 
 import yaml
 from yaml.parser import ParserError
@@ -176,6 +177,11 @@ class ScreenIO:
 
         # Update paths in configuration using appropriate string substitution
         self._format_config_paths(self.db_dir)
+
+        logger.debug("Importing the following argument namespace:")
+        logger.debug(pformat(vars(args)))
+        logger.debug("Running Screen with the following parameter set:")
+        logger.debug(pformat(self.config))
 
     def _load_config_from_yaml(self, config_filepath: str | os.PathLike) -> dict:
         """

--- a/commec/config/screen_io.py
+++ b/commec/config/screen_io.py
@@ -170,6 +170,7 @@ class ScreenIO:
         # Override configuration with any in user-provided YAML file
         cli_config_yaml=args.config_yaml.strip()
         if os.path.exists(cli_config_yaml):
+            logger.debug(f"Overriding defaults in {default_yaml} with values from {cli_config_yaml}")
             self._update_config_from_yaml(cli_config_yaml)
 
         # Override configuration with any user-provided CLI arguments
@@ -178,8 +179,6 @@ class ScreenIO:
         # Update paths in configuration using appropriate string substitution
         self._format_config_paths(self.db_dir)
 
-        logger.debug("Importing the following argument namespace:")
-        logger.debug(pformat(vars(args)))
         logger.debug("Running Screen with the following parameter set:")
         logger.debug(pformat(self.config))
 
@@ -216,8 +215,12 @@ class ScreenIO:
             )
 
         # Update the YAML default values in the configuration dictionary
+        logger.debug("Using the following CLI configuration arguments:")
+        logger.debug(pformat(args.user_specified_args))
+
         for arg in args.user_specified_args:
-             if arg in self.config and hasattr(args, arg):
+            if arg in self.config and hasattr(args, arg):
+                logger.debug(f"Command line arguments updated {arg} to {getattr(args,arg)}")
                 self.config[arg] = getattr(args, arg)
 
     def _format_config_paths(self,
@@ -240,6 +243,7 @@ class ScreenIO:
             try:
                 base_paths = self.config["base_paths"]
                 if db_dir_override is not None:
+                    logger.debug(f"Command line arguments updated base databases directory: {db_dir_override}")
                     base_paths["default"] = db_dir_override
                 else:
                     self.db_dir = base_paths["default"]

--- a/commec/config/screen_io.py
+++ b/commec/config/screen_io.py
@@ -220,7 +220,7 @@ class ScreenIO:
 
         for arg in args.user_specified_args:
             if arg in self.config and hasattr(args, arg):
-                logger.debug(f"Command line arguments updated {arg} to {getattr(args,arg)}")
+                logger.debug(f"Command line arguments updated '{arg}' to: {getattr(args,arg)}")
                 self.config[arg] = getattr(args, arg)
 
     def _format_config_paths(self,


### PR DESCRIPTION
## Background
We had an issue with -force result in -f -o rce, this may of been more quickly identified with more verbose debug logging. This PR aims to improve future argument and parameter visibility in a debug context.

## Changes
Prints the args.NameSpace and the screen parameters dictionary overidden by yaml after settings parsing to the debug log.

## Relevant logs, error messages, etc.
Example output:
```
 The Common Mechanism : Screen
────────┐
DEBUG   │ Parsing input parameters...
DEBUG   │ Imported the following arguments:
DEBUG   │ {'command': 'screen',
        │  'config_yaml': '../test_config.yaml\r',
        │  'database_dir': '/root/commec-dbs/',
        │  'diamond_jobs': None,
        │  'do_cleanup': False,
        │  'fasta_file': '../../../example_data/single.fasta',
        │  'force': False,
        │  'in_fast_mode': False,
        │  'output_prefix': '../test_foldseek/',
        │  'protein_search_tool': None,
        │  'resume': True,
        │  'skip_nt_search': False,
        │  'threads': 4,
        │  'user_specified_args': {'config_yaml',
        │                          'database_dir',
        │                          'output',
        │                          'output_prefix',
        │                          'resume',
        │                          'threads',
        │                          'verbose'},
        │  'verbose': True,
        │  'version': False}
DEBUG   │ Running Screen with the following parameter set:
DEBUG   │ {'base_paths': {'default': '/root/commec-dbs/'},
        │  'databases': {'benign': {'cm': {'path': '/root/commec-dbs/benign_db/benign.cm'},
        │                           'fasta': {'path': '/root/commec-dbs/benign_db/benign.fasta'},
        │                           'hmm': {'path': '/root/commec-dbs/benign_db/benign.hmm'}},
        │                'biorisk_hmm': {'annotations': '/root/commec-dbs/biorisk_db/biorisk_annotations.csv',
        │                                'path': '/root/commec-dbs/biorisk_db/biorisk.hmm'},
        │                'regulated_nt': {'path': '/root/commec-dbs/nt_igem_examples/nt_igem_examples'},
        │                'regulated_protein': {'blast': {'path': '/root/commec-dbs/pdb_nr/pdbaa'},
        │                                      'diamond': {'path': '/root/commec-dbs/nr_dmnd/nr.dmnd'},
        │                                      'protein_search_tool': 'blast'},
        │                'taxonomy': {'benign_taxids': '/root/commec-dbs/benign_db/vax_taxids.txt',
        │                             'path': '/root/commec-dbs/taxonomy/',
        │                             'regulated_taxids': '/root/commec-dbs/biorisk_db/reg_taxids.txt',
        │                             'regulated_vaxids': '/root/commec-dbs/biorisk_db/reg_taxids.txt',
        │                             'taxonomy_directory': '/root/commec-dbs/taxonomy/'}},
        │  'diamond_jobs': None,
        │  'do_cleanup': False,
        │  'force': False,
        │  'in_fast_mode': False,
        │  'protein_search_tool': 'blastx',
        │  'resume': True,
        │  'skip_nt_search': False,
        │  'threads': 4,
        │  'verbose': True}
INFO    │ Validating input query and databases...
```