### PR TITLE
Rebranded all --fast-mode references to -skip-taxonomy. 

### DIFF
--- a/commec/config/screen_io.py
+++ b/commec/config/screen_io.py
@@ -346,11 +346,11 @@ class ScreenIO:
 
     @property
     def should_do_protein_screening(self) -> bool:
-        return not self.config["in_fast_mode"]
+        return not self.config["skip_taxonomy_search"]
 
     @property
     def should_do_nucleotide_screening(self) -> bool:
-        return not (self.config["in_fast_mode"] or self.config["skip_nt_search"])
+        return not (self.config["skip_taxonomy_search"] or self.config["skip_nt_search"])
 
     @property
     def should_do_benign_screening(self) -> bool:

--- a/commec/screen-default-config.yaml
+++ b/commec/screen-default-config.yaml
@@ -26,7 +26,7 @@ threads: 1
 diamond_jobs: null
 do_cleanup: False
 force: False
-in_fast_mode: False
+skip_taxonomy_search: False
 protein_search_tool: 'blastx'
 resume: False
 skip_nt_search: False

--- a/commec/screen.py
+++ b/commec/screen.py
@@ -11,7 +11,7 @@ Screening involves (up to) four steps:
   4. Benign scan:       three different scans (against conserved proteins, housekeeping RNAs, and
                         synbio parts) to see if hits identified in homology search can be cleared.
 
-In "fast" mode, only the biorisk scan is run. By default, all four steps are run, but the nucleotide
+In "skip-taxonomy" mode, only the biorisk scan is run. By default, all four steps are run, but the nucleotide
 search is only run for regions that do not have any protein hits with a high sequence identity. The
 benign search is not permitted to clear biorisk scan hits, only protein or nucleotide hits. Whether
 or not a homology scan hit is from a regulated pathogen is determined by referencing the taxonomy
@@ -29,7 +29,7 @@ options:
   -v, --verbose         Output verbose (i.e. DEBUG-level) logs
 
 Screen run logic:
-  -f, --fast            Run in fast mode and skip protein and nucleotide homology search
+  -f, --skip-taxonomy   Skip taxonomy homology search (only toxins and other proteins includes in the biorisk database will be flagged)
   -p {blastx,diamond}, --protein-search-tool {blastx,diamond}
                         Tool for protein homology search to identify regulated pathogens
   -n, --skip-nt         Skip nucleotide search (regulated pathogens will only be identified based on
@@ -157,10 +157,19 @@ def add_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
     screen_logic_group = parser.add_argument_group("Screen run logic")
     screen_logic_group.add_argument(
         "-f",
-        "--fast",
-        dest="in_fast_mode",
+        "--skip-taxonomy",
+        dest="skip_taxonomy_search",
         action="store_true",
-        help="Run in fast mode and skip protein and nucleotide homology search",
+        help=("Skip taxonomy homology search (only toxins and other proteins"
+              " included in the biorisk database will be flagged)"),
+    )
+    screen_logic_group.add_argument(
+        "-n",
+        "--skip-nt",
+        dest="skip_nt_search",
+        action="store_true",
+        help=("Skip nucleotide search (regulated pathogens will only be"
+              " identified based on biorisk database and protein hits)"),
     )
     screen_logic_group.add_argument(
         "-p",
@@ -168,13 +177,6 @@ def add_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
         dest="protein_search_tool",
         choices=["blastx", "diamond"],
         help="Tool for protein homology search to identify regulated pathogens",
-    )
-    screen_logic_group.add_argument(
-        "-n",
-        "--skip-nt",
-        dest="skip_nt_search",
-        action="store_true",
-        help="Skip nucleotide search (regulated pathogens will only be identified based on protein hits)",
     )
     parallel_group = parser.add_argument_group("Parallelisation")
     parallel_group.add_argument(

--- a/commec/setup.py
+++ b/commec/setup.py
@@ -253,7 +253,7 @@ class CliSetup:
                         "\n -> type yes,y or no,n to indicate decision.",
                         "\n  (The Commec databases consist of a currated biorisk",
                         "\n  and benign database, which are required for commec to run",
-                        '\n  and are the only databases used in "--fast-mode")',
+                        '\n  and are the only databases used in "--skip-taxonomy")',
                     ]
                 )
                 continue
@@ -326,7 +326,7 @@ class CliSetup:
                     [
                         "\n -> type yes,y or no,n to indicate decision.",
                         "\n   (The Blast non-redundant protein database is used to screen",
-                        '\n   translated queries when not in "--fast-mode", and is ',
+                        '\n   translated queries when not in "--skip-taxonomy", and is ',
                         "\n   around 530 GB in size.)",
                     ]
                 )
@@ -362,7 +362,7 @@ class CliSetup:
                     [
                         "\n -> type yes,y or no,n to indicate decision.",
                         "\n   (The Blast Nucleotide database is used to screen",
-                        '\n   non-coding regions of queries when not in "--fast-mode",'
+                        '\n   non-coding regions of queries when not in "--skip-taxonomy",'
                         "\n   and is around 580 GB in size.)",
                     ]
                 )
@@ -394,7 +394,7 @@ class CliSetup:
                     [
                         "\n -> type yes,y or no,n to indicate decision.",
                         "\n   (A Taxonomy database is used to check taxonomy IDs",
-                        '\n   for regulation when not in "--fast-mode",'
+                        '\n   for regulation when not in "--skip-taxonomy",'
                         "\n   and is around 500 MB in size.)",
                     ]
                 )

--- a/commec/tests/test_io_params.py
+++ b/commec/tests/test_io_params.py
@@ -42,7 +42,7 @@ def expected_defaults():
         },
         "threads": 1,
         "protein_search_tool": "blastx",
-        "in_fast_mode": False,
+        "skip_taxonomy_search": False,
         "skip_nt_search": False,
         "do_cleanup": False,
         "diamond_jobs": None,
@@ -59,7 +59,7 @@ def custom_yaml_config():
                 "regulated_taxids" : "custom_path.txt"
             }
         },
-        "in_fast_mode": True,
+        "skip_taxonomy_search": True,
         "force": True,
         "threads": 8,
     }
@@ -95,7 +95,7 @@ def expected_updated_from_custom_yaml():
         },
         "threads": 8,
         "protein_search_tool": "blastx",
-        "in_fast_mode": True,
+        "skip_taxonomy_search": True,
         "skip_nt_search": False,
         "do_cleanup": False,
         "diamond_jobs": None,
@@ -147,7 +147,7 @@ def test_cli_override(tmp_path, expected_updated_from_custom_yaml, custom_yaml_c
         INPUT_QUERY,
         "--config",
         str(user_config_path),
-        "-f", # fast mode
+        "-f", # skip taxonomy
         "--skip-nt", # skip nt search
         "-c", # do_cleanup
         "-d",


### PR DESCRIPTION
kept -f as shorthand for 
a) compatibility, and 
b) -t is threads, and -s for skip is confusing with --skip-nt.

## Background
"The --fast-mode name suggests that this is just the better mode (why wouldn't you want to run the software fast), rather than a lightweight search that won't meet full regulatory compliance."

**Issues**:
Fixes issue #61

## Changes
* Altered the help text of --skip-nt to match format: Skip nucleotide search (regulated pathogens will only be identified based on biorisk database and protein hits)
* Altered all --fast-mode references to --skip-taxonomy.

### New features
* Added `-f`  `--skip-taxonomy`  `Skip taxonomy homology search (only toxins and other proteins included in the biorisk database will be flagged)`

### Breaking changes 
* Use of `--fast-mode` will no longer work, use `--skip-taxonomy` instead.

