### PR TITLE
Setup hotfix and DB location support

### DIFF
--- a/commec/setup.py
+++ b/commec/setup.py
@@ -60,7 +60,7 @@ class CliSetup:
 
         self.download_biorisk: bool = True
         self.default_biorisk_download_url: str = (
-            "https://f005.backblazeb2.com/file/common-mechanism-dbs/common-mechanism-dbs.zip"
+            "https://github.com/ibbis-bio/commec-databases/releases/download/v1.0.0/commec-dbs.zip"
         )
         self.biorisk_download_url: str = self.default_biorisk_download_url
 

--- a/commec/setup.py
+++ b/commec/setup.py
@@ -587,7 +587,7 @@ class CliSetup:
             )
             nt_directory = os.path.join(self.database_directory, "nt_blast")
             os.makedirs(nt_directory, exist_ok=True)
-            print(nr_directory)
+            print(nt_directory)
             command = ["update_blastdb.pl", "--decompress", self.blastnt_database]
             subprocess.run(command, cwd=nt_directory, check=True)
 


### PR DESCRIPTION
## Background
`commec setup` has a minor typo error which breaks nt database download. This fixes issues #65.
Furthermore, commec specific databases are now hosted in the commec-databases repository, and this now points to the latest vX.X.X database from that. Note this updates dynamically depending on the most recent tagged release in commec databases repo.

**Issues**:

Fixes issue #65 

## Changes
Changes the default url for biorisk and non-concern (transitionally benign) databases. The default URL is now updated according to what the most recent database is from the repository. If this fails, then no default is offered, and the usual process of the user entering in their own URL applies.

### Bug fixes
* Fixes a typo resulting in a crash when downloading the nt databases.
