### PR TITLE
Warnings for invalid user provided yaml fields

### DIFF
--- a/commec/config/screen_io.py
+++ b/commec/config/screen_io.py
@@ -205,7 +205,11 @@ class ScreenIO:
         not in the default YAML, will be ignored.
         """
         config_from_yaml = self._load_config_from_yaml(config_filepath)
-        self.config = deep_update(self.config, config_from_yaml)
+        self.config, rejected = deep_update(self.config, config_from_yaml)
+        for rejects in rejected:
+            logger.warning("The follow input from the user provided"
+                " configuration was not recognised: %s : %s",
+                rejects[0], rejects[1])
 
     def _update_config_from_cli(self, args: argparse.Namespace):
         """ 

--- a/commec/utils/dict_utils.py
+++ b/commec/utils/dict_utils.py
@@ -3,17 +3,25 @@
 """
 Static functions useful for dealing with common dictionary tasks.
 """
+import logging
+logger = logging.getLogger(__name__)
 
 @staticmethod
 def deep_update(to_update: dict, has_updates: dict):
     """
     Recursively update a nested dictionary without completely overwriting nested dictionaries.
     """
+    rejected = []
     updated = to_update.copy()
     for key, value in has_updates.items():
         # If both values are dictionaries, recursively update
         if key in updated and isinstance(updated[key], dict) and isinstance(value, dict):
-            updated[key] = deep_update(updated[key], value)
-        else:
+            updated[key], additional_rejects = deep_update(updated[key], value)
+            rejected.extend(additional_rejects)
+        # If not a dictionary, just copy the value.
+        elif key in updated:
             updated[key] = value
-    return updated
+        # If not present, we log an unexpected input one.
+        else:
+            rejected.append((key, value))
+    return updated, rejected

--- a/commec/utils/dict_utils.py
+++ b/commec/utils/dict_utils.py
@@ -3,13 +3,26 @@
 """
 Static functions useful for dealing with common dictionary tasks.
 """
-import logging
-logger = logging.getLogger(__name__)
 
 @staticmethod
-def deep_update(to_update: dict, has_updates: dict):
+def deep_update(to_update: dict[str, any], 
+                has_updates: dict[str, any]) -> tuple[
+                    dict[str,any], 
+                    list[tuple[str,any]]]:
     """
     Recursively update a nested dictionary without completely overwriting nested dictionaries.
+    Only already existing keys are updated. Any keys not existing in the dictionary
+    to be updated are returned as a list of rejected key value pairs.
+    -----
+    Inputs:
+    * to_update : dict[str, any] Dictionary to be updated.
+    * has_updates : dict[str, any] New dictionary information to be added.
+    ----
+    Outputs:
+    * updated : dict[str, any] a copy of the to_update dictionary, with values
+    from any matching keys overridden by has_updates.
+    * rejected : list[tuple[str,any] A list of the rejected key value pairs, i.e. 
+    keys present in has_updates, but not present in to_update.
     """
     rejected = []
     updated = to_update.copy()


### PR DESCRIPTION
## Background
When using a custom yaml, and you provided an incorrect key, this was silently ignored - which is not ideal behaviour. Now we warn the user of any fields in their provided yaml which prevents accidentally expecting a setting to work when it has been input incorrectly.


## Relevant logs, error messages, etc.
Example output - see warnings:
```
 The Common Mechanism : Screen
────────┐
DEBUG   │ Parsing input parameters...
DEBUG   │ Overriding defaults in /root/repo/working/common-mechanism/commec/screen-default-config.yaml with values from
        │ ../test_config.yaml
WARNING │ The follow input from the user provided configuration was not recognised: legacy_benign : {'path': 'badpath'}
WARNING │ The follow input from the user provided configuration was not recognised: this_should_be_here : tehe
DEBUG   │ Using the following CLI configuration arguments:
DEBUG   │ {'config_yaml',
        │  'database_dir',
        │  'output',
        │  'output_prefix',
        │  'resume',
        │  'threads',
        │  'verbose'}
DEBUG   │ Command line arguments updated 'verbose' to: True
DEBUG   │ Command line arguments updated 'threads' to: 4
DEBUG   │ Command line arguments updated 'resume' to: True
DEBUG   │ Command line arguments updated base databases directory: /root/commec-dbs/
DEBUG   │ Running Screen with the following parameter set:
DEBUG   │ {'base_paths': {'default': '/root/commec-dbs/'},
        │  'databases': {'benign': {'cm': {'path': '/root/commec-dbs/benign_db/benign.cm'},
        │                           'fasta': {'path': '/root/commec-dbs/benign_db/benign.fasta'},
        │                           'hmm': {'path': '/root/commec-dbs/benign_db/benign.hmm'}},
        │                'biorisk_hmm': {'annotations': '/root/commec-dbs/biorisk_db/biorisk_annotations.csv',
        │                                'path': '/root/commec-dbs/biorisk_db/biorisk.hmm'},
        │                'regulated_nt': {'path': '/root/commec-dbs/nt_igem_examples/nt_igem_examples'},
        │                'regulated_protein': {'blast': {'path': '/root/commec-dbs/pdb_nr/pdbaa'},
        │                                      'diamond': {'path': '/root/commec-dbs/nr_dmnd/nr.dmnd'}},
        │                'taxonomy': {'benign_taxids': '/root/commec-dbs/benign_db/vax_taxids.txt',
        │                             'path': '/root/commec-dbs/taxonomy/',
        │                             'regulated_taxids': '/root/commec-dbs/biorisk_db/reg_taxids.txt'}},
```