### PR TITLE
Remove requests dependancy

### DIFF
--- a/.github/workflows/automate_tests.yml
+++ b/.github/workflows/automate_tests.yml
@@ -1,0 +1,30 @@
+name: Test Commec
+
+on:
+  pull_request:
+    branches:
+      - develop
+      - main
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Conda environment
+        uses: conda-incubator/setup-miniconda@v3
+        with:
+          activate-environment: commec-env
+          environment-file: environment.yaml
+          auto-activate-base: false
+          clean-patched-environment-file: true
+
+      - name: Run tests
+        shell: bash -l {0}
+        run: |
+          conda activate commec-env
+          pytest -vv


### PR DESCRIPTION
## Background
When adding commec database versioning functionality, we used requests module, rather than the urllib.request module already in use. This changes that such that the requests module - which is not part of the standard python library - will not be needed as a bloating dependency.
