### PR TITLE
Include Synthetic Constructs in query has hits logic

### DIFF
--- a/commec/config/constants.py
+++ b/commec/config/constants.py
@@ -3,3 +3,4 @@
 
 DEFAULT_CONFIG_YAML_PATH = "screen-default-config.yaml"
 MINIMUM_QUERY_LENGTH = 41
+MINIMUM_PERCENT_IDENTITY = 20 # How much is required to say "is close enough to something we know of"

--- a/commec/config/constants.py
+++ b/commec/config/constants.py
@@ -3,4 +3,3 @@
 
 DEFAULT_CONFIG_YAML_PATH = "screen-default-config.yaml"
 MINIMUM_QUERY_LENGTH = 41
-MINIMUM_PERCENT_IDENTITY = 20 # How much is required to say "is close enough to something we know of"

--- a/commec/screeners/check_reg_path.py
+++ b/commec/screeners/check_reg_path.py
@@ -15,8 +15,6 @@ import re
 import sys
 import textwrap
 import pandas as pd
-#from commec.config.screen_tools import ScreenIO
-from commec.config.constants import MINIMUM_PERCENT_IDENTITY
 from commec.tools.blast_tools import read_blast, get_taxonomic_labels, get_top_hits
 from commec.tools.blastn import BlastNHandler
 from commec.tools.search_handler import SearchHandler
@@ -113,16 +111,15 @@ def update_taxonomic_data_from_database(
     logger.debug("%s Blast Import: shape: %s preview:\n%s", step, blast.shape, blast.head())
 
     # Initial check for query to be identified as anything known.
-    grouped = blast.groupby("query acc.")["% identity"]
-    for query_acc, pc_identity in grouped:
-        if (pc_identity > MINIMUM_PERCENT_IDENTITY).any():
-            query_obj = queries.get(query_acc)
-            if query_obj:
-                logger.debug("Confirming hits for query %s.", query_acc)
-                query_obj.confirm_has_hits()
-            else:
-                logger.error("Could not mark query %s for confirmation of hit, "
-                             "query not found in input queries.", query_acc)
+    unique_queries = blast['query acc.'].unique()
+    for query_acc in unique_queries:
+        query_obj = queries.get(query_acc)
+        if query_obj:
+            logger.debug("Confirming hits for query %s.", query_acc)
+            query_obj.confirm_has_hits()
+        else:
+            logger.error("Could not mark query %s for confirmation of hit, "
+                            "query not found in input queries.", query_acc)
 
     # Add taxonomic labels, and filter synthetic constructs
     blast = get_taxonomic_labels(blast, reg_taxids, vax_taxids, taxonomy_directory, n_threads)


### PR DESCRIPTION
## Background
get_taxonomic_labels currently filters out synthetic constructs when adding the labels. This means that when checking taxonomic results, those hits were being excluded when checking whether or not the query had any hits at all. This was leading to some queries which were wholly synthetic constructs being mis-labelled as Warnings, due to being mysteriously lacking in any know taxonomic hit.

## Changes
A check for hits is performed on the blast outputs directly, before any filtering takes place. (Rather than just on the top hits of non-synthetic constructs). These are compared to a new constant, `MINIMUM_PERCENT_IDENTITY`, currently defaulted to 20, for above which a hit is considered close enough to be like the query, and the query can be confirmed it has a hit, and is therefore not an unidentified sequence.
