### PR TITLE
Database validation override

### DIFF
--- a/commec/screen.py
+++ b/commec/screen.py
@@ -469,7 +469,7 @@ class Screen:
         """
         logger.debug("\t...running %s", self.params.config["protein_search_tool"])
         self.database_tools.regulated_protein.search()
-        if not self.database_tools.regulated_protein.check_output():
+        if not self.database_tools.regulated_protein.validate_output():
             self.reset_query_statuses(ScreenStep.TAXONOMY_AA, ScreenStatus.ERROR)
             raise RuntimeError(
                 "ERROR: Expected protein search output not created: "
@@ -534,7 +534,7 @@ class Screen:
         # Only run new blastn search if there are no previous results
         self.database_tools.regulated_nt.search()
 
-        if not self.database_tools.regulated_nt.check_output():
+        if not self.database_tools.regulated_nt.validate_output():
             self.reset_query_statuses(ScreenStep.TAXONOMY_NT, ScreenStatus.ERROR)
             raise RuntimeError(
                 "ERROR: Expected nucleotide search output not created: "

--- a/commec/screeners/check_biorisk.py
+++ b/commec/screeners/check_biorisk.py
@@ -75,7 +75,7 @@ def update_biorisk_data_from_database(search_handle : HmmerHandler,
     if not os.path.exists(hmm_folder_csv):
         logger.error("\t...biorisk_annotations.csv does not exist\n %s", hmm_folder_csv)
         return 1
-    if not search_handle.check_output():
+    if not search_handle.validate_output():
         logger.error("\t...database output file does not exist\n %s", search_handle.out_file)
         return 1
     if search_handle.is_empty(search_handle.out_file):

--- a/commec/screeners/check_reg_path.py
+++ b/commec/screeners/check_reg_path.py
@@ -45,7 +45,7 @@ def _check_inputs(
     returns True if it is safe to continue. 
     """
     # check input files
-    if not search_handle.check_output():
+    if not search_handle.validate_output():
         logger.info("\t...ERROR: Taxonomic search results empty\n %s", search_handle.out_file)
         return False
 

--- a/commec/tests/test_check_biorisk.py
+++ b/commec/tests/test_check_biorisk.py
@@ -47,7 +47,7 @@ def test_check_biorisk_return_codes(annotations_exists, is_empty, has_hits, expe
         patch("pandas.read_csv", return_value=mock_annot_df),
         patch("commec.screeners.check_biorisk.readhmmer", return_value=mock_hit_df),
         patch("commec.screeners.check_biorisk.remove_overlaps", return_value=mock_hit_df),
-        patch("commec.screeners.check_biorisk.HmmerHandler.check_output", return_value=True),
+        patch("commec.screeners.check_biorisk.HmmerHandler.validate_output", return_value=True),
         patch("commec.screeners.check_biorisk.HmmerHandler.is_empty", return_value=is_empty),
         patch("commec.screeners.check_biorisk.HmmerHandler.has_hits", return_value=has_hits),
     ):

--- a/commec/tests/test_dbs.py
+++ b/commec/tests/test_dbs.py
@@ -45,7 +45,7 @@ def test_database_can_run(input_db):
 
     new_db = input_db[0](db_file, INPUT_QUERY, output_file, force=True)
     new_db.search()
-    assert new_db.check_output()
+    assert new_db.validate_output()
 
     version: str = new_db.get_version_information()
     assert version

--- a/commec/tools/search_handler.py
+++ b/commec/tools/search_handler.py
@@ -66,7 +66,10 @@ class SearchHandler(ABC):
         self.force = kwargs.get('force', False)
         self.arguments_dictionary = {}
 
-        self._validate_db()
+        # Only check database files validating if we actually intend on using them.
+        if self.force or not self.check_output():
+            self._validate_db()
+
         self.version_info = self.get_version_information()
 
     @property


### PR DESCRIPTION
## Background
Adds a simply database override statement such that if `-R, --resume` is used, and the expected output already exists (i.e. the database handler would not run the search anyway, then the database files themselves are not checked for existence / validity. 

This allows the complete run of a commec screen based on pre-existing output alone - with no large external database file setup [biorisk/nr/nt/benign]. 

This is useful for testing, reproducibility, and tutorial purposes.

Note, we still require correct config yaml imports of the annotations and taxid files for biorisk and benign - these are however very lightweight, and could be bundled with a yaml easily for tutorial output purposes.