### PR TITLE
Extra taxonomic info

### DIFF
--- a/commec/tests/test_data/functional.json
+++ b/commec/tests/test_data/functional.json
@@ -158,13 +158,16 @@
                                 "regulated_eukaryotes": "0",
                                 "regulated_bacteria": "0",
                                 "regulated_viruses": "1",
-                                "regulated_taxids": [
-                                    "12345"
+                                "regulated_taxa": [
+                                    {
+                                        "taxid": 12345,
+                                        "name": "species",
+                                        "kingdom": "Viruses",
+                                        "target_hit": "        NR_HIT_FLAG4",
+                                        "target_description": "ShouldClear"
+                                    }
                                 ],
-                                "non_regulated_taxids": [],
-                                "regulated_species": [
-                                    "species"
-                                ]
+                                "non_regulated_taxa": []
                             }
                         ]
                     }
@@ -196,13 +199,16 @@
                                 "regulated_eukaryotes": "0",
                                 "regulated_bacteria": "0",
                                 "regulated_viruses": "1",
-                                "regulated_taxids": [
-                                    "12345"
+                                "regulated_taxa": [
+                                    {
+                                        "taxid": 12345,
+                                        "name": "species",
+                                        "kingdom": "Viruses",
+                                        "target_hit": "    NR_HIT_FLAG1",
+                                        "target_description": "ShouldntClear"
+                                    }
                                 ],
-                                "non_regulated_taxids": [],
-                                "regulated_species": [
-                                    "species"
-                                ]
+                                "non_regulated_taxa": []
                             }
                         ]
                     }
@@ -234,15 +240,30 @@
                                 "regulated_eukaryotes": "0",
                                 "regulated_bacteria": "0",
                                 "regulated_viruses": "1",
-                                "regulated_taxids": [
-                                    "12345"
+                                "regulated_taxa": [
+                                    {
+                                        "taxid": 12345,
+                                        "name": "species",
+                                        "kingdom": "Viruses",
+                                        "target_hit": "    NR_HIT_MIXED",
+                                        "target_description": "ShouldMixedReg"
+                                    }
                                 ],
-                                "non_regulated_taxids": [
-                                    "12346",
-                                    "12347"
-                                ],
-                                "regulated_species": [
-                                    "species"
+                                "non_regulated_taxa": [
+                                    {
+                                        "taxid": 12346,
+                                        "name": "species",
+                                        "kingdom": "Viruses",
+                                        "target_hit": "NR_HIT_MIXED",
+                                        "target_description": "ShouldMixednonReg"
+                                    },
+                                    {
+                                        "taxid": 12347,
+                                        "name": "species",
+                                        "kingdom": "Viruses",
+                                        "target_hit": "NR_HIT_MIXED",
+                                        "target_description": "ShouldMixedNonReg"
+                                    }
                                 ]
                             }
                         ]
@@ -275,13 +296,23 @@
                                 "regulated_eukaryotes": "0",
                                 "regulated_bacteria": "0",
                                 "regulated_viruses": "1",
-                                "regulated_taxids": [
-                                    "12345"
+                                "regulated_taxa": [
+                                    {
+                                        "taxid": 12345,
+                                        "name": "species",
+                                        "kingdom": "Viruses",
+                                        "target_hit": "NR_HIT_FLAG2",
+                                        "target_description": "ShouldClearBySynbio"
+                                    },
+                                    {
+                                        "taxid": 12345,
+                                        "name": "species",
+                                        "kingdom": "Viruses",
+                                        "target_hit": "    NR_HIT_FLAG3",
+                                        "target_description": "ShouldntClear"
+                                    }
                                 ],
-                                "non_regulated_taxids": [],
-                                "regulated_species": [
-                                    "species"
-                                ]
+                                "non_regulated_taxa": []
                             }
                         ]
                     }
@@ -313,13 +344,23 @@
                                 "regulated_eukaryotes": "0",
                                 "regulated_bacteria": "0",
                                 "regulated_viruses": "1",
-                                "regulated_taxids": [
-                                    "12345"
+                                "regulated_taxa": [
+                                    {
+                                        "taxid": 12345,
+                                        "name": "species",
+                                        "kingdom": "Viruses",
+                                        "target_hit": "NR_HIT_FLAG2",
+                                        "target_description": "ShouldClearBySynbio"
+                                    },
+                                    {
+                                        "taxid": 12345,
+                                        "name": "species",
+                                        "kingdom": "Viruses",
+                                        "target_hit": "    NR_HIT_FLAG3",
+                                        "target_description": "ShouldntClear"
+                                    }
                                 ],
-                                "non_regulated_taxids": [],
-                                "regulated_species": [
-                                    "species"
-                                ]
+                                "non_regulated_taxa": []
                             }
                         ]
                     }
@@ -351,13 +392,23 @@
                                 "regulated_eukaryotes": "0",
                                 "regulated_bacteria": "0",
                                 "regulated_viruses": "1",
-                                "regulated_taxids": [
-                                    "12345"
+                                "regulated_taxa": [
+                                    {
+                                        "taxid": 12345,
+                                        "name": "species",
+                                        "kingdom": "Viruses",
+                                        "target_hit": "NT_HIT_FLAG2",
+                                        "target_description": "SUBJECT"
+                                    },
+                                    {
+                                        "taxid": 12345,
+                                        "name": "species",
+                                        "kingdom": "Viruses",
+                                        "target_hit": "NT_HIT_FLAG3",
+                                        "target_description": "SUBJECT"
+                                    }
                                 ],
-                                "non_regulated_taxids": [],
-                                "regulated_species": [
-                                    "species"
-                                ]
+                                "non_regulated_taxa": []
                             }
                         ]
                     }
@@ -389,13 +440,23 @@
                                 "regulated_eukaryotes": "0",
                                 "regulated_bacteria": "0",
                                 "regulated_viruses": "1",
-                                "regulated_taxids": [
-                                    "12345"
+                                "regulated_taxa": [
+                                    {
+                                        "taxid": 12345,
+                                        "name": "species",
+                                        "kingdom": "Viruses",
+                                        "target_hit": "NT_HIT_FLAG2",
+                                        "target_description": "SUBJECT"
+                                    },
+                                    {
+                                        "taxid": 12345,
+                                        "name": "species",
+                                        "kingdom": "Viruses",
+                                        "target_hit": "NT_HIT_FLAG3",
+                                        "target_description": "SUBJECT"
+                                    }
                                 ],
-                                "non_regulated_taxids": [],
-                                "regulated_species": [
-                                    "species"
-                                ]
+                                "non_regulated_taxa": []
                             }
                         ]
                     }
@@ -427,13 +488,16 @@
                                 "regulated_eukaryotes": "0",
                                 "regulated_bacteria": "0",
                                 "regulated_viruses": "1",
-                                "regulated_taxids": [
-                                    "12345"
+                                "regulated_taxa": [
+                                    {
+                                        "taxid": 12345,
+                                        "name": "species",
+                                        "kingdom": "Viruses",
+                                        "target_hit": "NT_HIT_FLAG1",
+                                        "target_description": "SUBJECT"
+                                    }
                                 ],
-                                "non_regulated_taxids": [],
-                                "regulated_species": [
-                                    "species"
-                                ]
+                                "non_regulated_taxa": []
                             }
                         ]
                     }
@@ -465,14 +529,23 @@
                                 "regulated_eukaryotes": "0",
                                 "regulated_bacteria": "0",
                                 "regulated_viruses": "1",
-                                "regulated_taxids": [
-                                    "12345"
+                                "regulated_taxa": [
+                                    {
+                                        "taxid": 12345,
+                                        "name": "species",
+                                        "kingdom": "Viruses",
+                                        "target_hit": "NT_HIT_MIXED",
+                                        "target_description": "Main"
+                                    }
                                 ],
-                                "non_regulated_taxids": [
-                                    "12346"
-                                ],
-                                "regulated_species": [
-                                    "species"
+                                "non_regulated_taxa": [
+                                    {
+                                        "taxid": 12346,
+                                        "name": "species",
+                                        "kingdom": "Viruses",
+                                        "target_hit": "NT_HIT_MIXED2",
+                                        "target_description": "NonRegMixedWithMain"
+                                    }
                                 ]
                             }
                         ]

--- a/commec/utils/json_html_output.py
+++ b/commec/utils/json_html_output.py
@@ -220,9 +220,11 @@ def generate_outcome_string(query : QueryResult, hit : HitResult) -> str:
                 n_regulated_eukaryotes += int(r["regulated_eukaryotes"])
                 n_regulated_bacteria += int(r["regulated_bacteria"])
                 n_regulated_viruses += int(r["regulated_viruses"])
-                regulated_taxids.extend(r["regulated_taxids"])
-                non_regulated_taxids.extend(r["non_regulated_taxids"])
-                regulated_species.extend(r["regulated_species"])
+                regulated_taxids.extend(r["regulated_taxa"])
+                non_regulated_taxids.extend(r["non_regulated_taxa"])
+            
+            for entry in regulated_taxids:
+                regulated_species.append(entry["name"])
             
             domain_string = " across multiple domains."
             if n_regulated_bacteria > 0 and n_regulated_viruses == 0 and n_regulated_eukaryotes == 0:


### PR DESCRIPTION
## Background
Whilst initially we aimed to keep the taxonomy taxid summary information in the json concise, in practice it is more helpful to have descriptions, species, and kingdom information for each taxonomy entry that is associated with a hit region.


**Issues**:
Issue #8 from commec dev.

## Changes

Here we change the custom data output for the taxonomy field in the json from:

      "regulated_taxids": [
          "376619"
      ],
      "non_regulated_taxids": [
          "100673",
          "559292",
          "9606"
      ],
      "regulated_species": [
          "Francisella tularensis"
      ]
      
to the more verbose:

```
                                "regulated_taxa": [
                                    {
                                        "taxid": 632,
                                        "name": "Yersinia pestis",
                                        "kingdom": "Bacteria",
                                        "target_hit": "1QZ0_A",
                                        "target_description": "Chain A, Protein-tyrosine phosphatase yopH [Yersinia pestis]"
                                    }
                                ],
                                "non_regulated_taxa": [
                                    {
                                        "taxid": 630,
                                        "name": "Yersinia enterocolitica",
                                        "kingdom": "Bacteria",
                                        "target_hit": "1QZ0_A",
                                        "target_description": "Chain A, Protein-tyrosine phosphatase yopH [Yersinia pestis]"
                                    },
                                    {
                                        "taxid": 630,
                                        "name": "Yersinia enterocolitica",
                                        "kingdom": "Bacteria",
                                        "target_hit": "1XXV_A",
                                        "target_description": "Chain A, Protein-tyrosine phosphatase yopH [Yersinia enterocolitica]"
                                    },
                                    {
                                        "taxid": 630,
                                        "name": "Yersinia enterocolitica",
                                        "kingdom": "Bacteria",
                                        "target_hit": "1YPT_A",
                                        "target_description": "Chain A, PROTEIN-TYROSINE PHOSPHATASE YERSINIA (CATALYTIC DOMAIN) [Yersinia enterocolitica]"
                                    }
                                ]
```

### Breaking changes 
* The format of the "formatless" regulated_taxonomy dict for protein and nucleotide taxonomy hit entries now contains the aforementioned structure, which may affect third party json interpreters. Such changes have been accounted for internally where used such as the html generator script.

## Relevant logs, error messages, etc.
No changes to existing logs / error messages / taxonomy detection behaviour etc.