### PR TITLE
Fix path creation in commec flag

### DIFF
--- a/commec/flag.py
+++ b/commec/flag.py
@@ -9,7 +9,7 @@ positional arguments:
 options:
   -r, --recursive      show this help message and exit
   -o, --output OUTPUT_DIR
-                       path where output CSVs should be written
+                       path where output CSVs should be written, created if it does not exist
 
 The screen_pipline_status covers the status of the 4 screening steps, while flags.csv has just
 flag outcomes for various things that commec can flag, and flags_recommended just has an overall
@@ -25,7 +25,7 @@ import pandas as pd
 
 from commec.config.json_io import IoVersionError, get_screen_data_from_json
 from commec.config.result import Rationale, ScreenResult, ScreenStatus, ScreenStep
-from commec.utils.file_utils import directory_arg
+from commec.utils.file_utils import directory_arg, expand_and_normalize
 
 DESCRIPTION = (
     "Parse all .screen, or .json files in a directory and create CSVs of flags raised"
@@ -52,9 +52,9 @@ def add_args(parser: argparse.ArgumentParser):
     parser.add_argument(
         "-o",
         "--output",
-        type=directory_arg,
         default=None,
-        help="Output directory name (defaults to directory if not provided)",
+        help="Output directory name, created if it does not exist"
+        " (defaults to directory if not provided)",
     )
     parser.add_argument(
         "-e",
@@ -235,8 +235,17 @@ def run(args: argparse.Namespace):
     """
     search_dir = args.directory
     search_recursive = args.recursive
-    output_dir = args.output or os.path.dirname(search_dir)
+    output_dir = expand_and_normalize(args.output or os.path.dirname(search_dir))
     evalportal_format = args.evalportal_format
+
+    # The output directory is written to at the end of the run, so create it (and any missing
+    # parents) up front, rather than failing once all the screen files have been parsed.
+    try:
+        os.makedirs(output_dir, exist_ok=True)
+    except OSError as e:
+        raise NotADirectoryError(
+            f"Could not create output directory: {output_dir} ({e})"
+        ) from e
 
     search_pattern = "**/*.json" if search_recursive else "*.json"
     screen_paths = glob.glob(

--- a/commec/flag.py
+++ b/commec/flag.py
@@ -238,8 +238,6 @@ def run(args: argparse.Namespace):
     output_dir = expand_and_normalize(args.output or os.path.dirname(search_dir))
     evalportal_format = args.evalportal_format
 
-    # The output directory is written to at the end of the run, so create it (and any missing
-    # parents) up front, rather than failing once all the screen files have been parsed.
     try:
         os.makedirs(output_dir, exist_ok=True)
     except OSError as e:

--- a/commec/tests/test_flag.py
+++ b/commec/tests/test_flag.py
@@ -2,6 +2,8 @@ import argparse
 import os
 import textwrap
 
+import pytest
+
 from commec.flag import add_args, run
 
 SCREEN_DIR = os.path.join(os.path.dirname(__file__), "test_data")
@@ -34,6 +36,34 @@ def test_flag(tmp_path):
     )
     actual_status = status_output.read_text()
     assert expected_status.strip() == actual_status.strip()
+
+
+@pytest.mark.parametrize("suffix", ["new_dir", "new/nested/dir", "new_dir/"])
+def test_flag_creates_missing_output_directory(tmp_path, suffix):
+    """An output directory passed to -o is created if it doesn't already exist."""
+    output_dir = tmp_path / suffix
+    assert not output_dir.exists()
+
+    parser = argparse.ArgumentParser()
+    add_args(parser)
+    args = parser.parse_args([SCREEN_DIR, "-o", str(output_dir), "-r"])
+    run(args)
+
+    assert output_dir.is_dir()
+    assert (output_dir / "screen_pipeline_status.csv").exists()
+
+
+def test_flag_errors_if_output_directory_cannot_be_created(tmp_path):
+    """A clear error is raised when the output directory cannot be created."""
+    blocker = tmp_path / "not_a_dir"
+    blocker.write_text("")
+
+    parser = argparse.ArgumentParser()
+    add_args(parser)
+    args = parser.parse_args([SCREEN_DIR, "-o", str(blocker / "output"), "-r"])
+
+    with pytest.raises(NotADirectoryError):
+        run(args)
 
 
 def test_evalportal_format(tmp_path):

--- a/uv.lock
+++ b/uv.lock
@@ -1,8 +1,0 @@
-version = 1
-revision = 3
-requires-python = ">=3.10"
-
-[[package]]
-name = "commec"
-version = "2.0.0"
-source = { editable = "." }

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,8 @@
+version = 1
+revision = 3
+requires-python = ">=3.10"
+
+[[package]]
+name = "commec"
+version = "2.0.0"
+source = { editable = "." }


### PR DESCRIPTION
## Background
A user reported the following error:

> commec flag needs a pre-existing directory. Errored on a missing output path; the core screen step was unaffected.

This PR aims to fix that.

## Changes
### Bug fixes
* Create the output directory and its parents up front, rather than failing once all the screen files have been parsed.