### PR TITLE
Control list output hotfix

### DIFF
--- a/commec/control_list/cli.py
+++ b/commec/control_list/cli.py
@@ -151,7 +151,7 @@ def generate_output_summary_csv(output_filepath: str | os.PathLike):
     """
     # Deferred import: control_list imports this module, so importing at
     # module level here would create a circular import.
-    from .control_list import get_regulation
+    from .control_list import get_regulation, get_control_lists
 
     # One row per accession (there may be multiple rows per index, one per list).
     output_data = (
@@ -172,6 +172,14 @@ def generate_output_summary_csv(output_filepath: str | os.PathLike):
             output_data.loc[accession, regulation.list] = 1
 
     output_data = output_data.sort_values("display_name")
+
+    # Rename the control list headings to the str of the list object
+    rename_headings = {}
+    for col_heading in output_data.columns:
+        _list = get_control_lists(col_heading)
+        if _list:
+            rename_headings[col_heading] = _list.__repr__()
+    output_data = output_data.rename(columns=rename_headings)
 
     # Export - ensure .csv suffix
     output_path = Path(output_filepath).resolve()

--- a/commec/control_list/cli.py
+++ b/commec/control_list/cli.py
@@ -151,7 +151,7 @@ def generate_output_summary_csv(output_filepath: str | os.PathLike):
     """
     # Deferred import: control_list imports this module, so importing at
     # module level here would create a circular import.
-    from .control_list import get_control_lists, get_regulation 
+    from .control_list import get_control_lists, get_regulation
 
     # One row per accession (there may be multiple rows per index, one per list).
     output_data = (

--- a/commec/control_list/cli.py
+++ b/commec/control_list/cli.py
@@ -151,7 +151,7 @@ def generate_output_summary_csv(output_filepath: str | os.PathLike):
     """
     # Deferred import: control_list imports this module, so importing at
     # module level here would create a circular import.
-    from .control_list import get_regulation, get_control_lists
+    from .control_list import get_control_lists, get_regulation 
 
     # One row per accession (there may be multiple rows per index, one per list).
     output_data = (

--- a/commec/control_list/containers.py
+++ b/commec/control_list/containers.py
@@ -217,7 +217,7 @@ class ControlList:
         """
         acronym = self.acronym
         if self.acronym.startswith(self.region.acronym):
-            acronym = self.acronym[len(self.region.acronym):]
+            acronym = self.acronym[len(self.region.acronym) :]
         return f"{self.region.acronym}_{acronym}"
 
     def __str__(self):

--- a/commec/control_list/containers.py
+++ b/commec/control_list/containers.py
@@ -206,12 +206,28 @@ class ControlList:
         else:
             self.display_name = self.name
 
+    def __repr__(self):
+        """
+        Shorthand acroynms for list comprehension. e.g:
+        AG_CCL, or IN_SCOMET.
+        Describes the region affect, the acronym, and the use in a single line.
+        For JSON and logging reporting purposes.
+        It also abbreviated the acronym if the region is in the acroynm:
+        USCCL becomes US_CCL instead of US_USCCL.
+        """
+        acronym = self.acronym
+        if self.acronym.startswith(self.region.acronym):
+            acronym = self.acronym[len(self.region.acronym):]
+        return f"{self.region.acronym}_{acronym}"
+
     def __str__(self):
         """
         Shorthand acroynms for list comprehension. e.g:
-        AG_CCL_EXPORT, or IN_SCOMET_EXPORT.
+        AG_CCL, or IN_SCOMET.
         Describes the region affect, the acronym, and the use in a single line.
         For JSON and logging reporting purposes.
+        It also abbreviated the acronym if the region is in the acroynm:
+        USCCL becomes US_CCL instead of US_USCCL.
         """
         return f"{self.region.acronym}_{self.acronym}_{self.use}"
 

--- a/commec/control_list/control_list.py
+++ b/commec/control_list/control_list.py
@@ -365,9 +365,7 @@ def run(arguments: argparse.Namespace):
             )
 
     if arguments.output_prefix:
-        logger.info(
-            'Writing output list summary to "%s" ...', arguments.output_prefix
-        )
+        logger.info('Writing output list summary to "%s" ...', arguments.output_prefix)
         generate_output_summary_csv(arguments.output_prefix)
 
     logger.info("", extra={"no_prefix": True, "box_up": True})

--- a/commec/control_list/control_list.py
+++ b/commec/control_list/control_list.py
@@ -366,7 +366,7 @@ def run(arguments: argparse.Namespace):
 
     if arguments.output_prefix:
         logger.info(
-            'Writing output list summary to "%s.csv" ...', arguments.output_prefix
+            'Writing output list summary to "%s" ...', arguments.output_prefix
         )
         generate_output_summary_csv(arguments.output_prefix)
 

--- a/commec/tests/test_control_list_cli.py
+++ b/commec/tests/test_control_list_cli.py
@@ -215,8 +215,8 @@ def test_generate_output_summary_csv(tmp_path):
     assert output_path.exists()
     df = pd.read_csv(output_path)
     # One-hot encoded list acronym columns should be present
-    assert "EC" in df.columns
-    assert "PL" in df.columns
+    assert "NZ_EC" in df.columns
+    assert "AU_PL" in df.columns
 
 
 def test_generate_output_summary_csv_suffix_correction(tmp_path):


### PR DESCRIPTION
## Background
Updates the column headings of the output csv for commec list to be a) inline with the blog post we're writing, and b) easier for a human to understand:

CN_DUPRC,ZA_EC,AG_CCL,AG_PPCCL,IN_SCOMET,EU_LAP,EU_DUECR,RU_RFECHA,RU_RFECA,US_BSATHHS,US_BSATUSDA,US_PPQUSDA,US_CCL,US_ML,BR_CIBES,UK_SAPO,UK_ATCSA,UK_COSHH,UK_SECL

In short, the region acronym is appended to the front, AND is removed from the front of the list acronym if it was there. i.e. USCCL becomes US_CCL instead of US_USCCL. etc.