### PR TITLE
Update environment.yaml 

### DIFF
--- a/environment.yaml
+++ b/environment.yaml
@@ -11,24 +11,23 @@ dependencies:
   - pandas
   - pyyaml
   - pycountry
+  # Runtime GUI (web kiosk) server deps
+  - flask
   - openpyxl
   - xlrd
-  - xlwt
-  # Web GUI (`commec gui`)
-  - flask
+  - werkzeug
   - psutil
+  - mkcert
   # Runtime non-Python dependencies
   - blast>=2.17
   - hmmer
   - infernal
-  - yaml
-  - wget
   - tar
   - zstd
   # Development dependencies
   - pip
   - pytest
-  - matplotlib
+  - xlwt
   - ruff>=0.15.10,<0.16.0
   - pip:
       - -e .


### PR DESCRIPTION
## Background
The `environment.yaml` tracks all the dependencies post #151. This PR audits every entry in  `environment.yaml` against actual usage in the codebase (imports, `subprocess` calls, shell scripts) and fixes it up.

## Changes

* Add `werkzeug` — `commec/gui/server.py` imports `werkzeug.security.check_password_hash` directly.
* Add `mkcert` — `commec/gui/gen-cert.sh` hard-requires the `mkcert` binary to issue the GUI's TLS certs.
* Move `xlwt` from the GUI deps block to Development deps — it's only used to generate `.xls` fixtures in `commec/tests/test_gui_inputs.py`; the GUI server itself only reads `.xls` (via `xlrd`), never writes it.
* Remove `matplotlib` — unused anywhere in the codebase (confirmed via full import scan).
* Remove `yaml` — this is libyaml, the C library backing `pyyaml`'s bindings, not a tool commec calls directly. `pyyaml` already pins `yaml >=0.2.5` as its own dependency, so listing it explicitly was redundant and miscategorized it alongside actual CLI tools (blast/hmmer/infernal/tar/zstd).
* Remove `wget` — nothing in commec invokes `wget` (downloads go through stdlib `urllib.request` in `commec/setup.py`). It's still pulled in transitively via `blast` → `entrez-direct`, so removing the explicit pin doesn't change what gets installed.
* Consolidate the GUI dependency comment block: `flask`, `openpyxl`, `xlrd`, `werkzeug`, `psutil`, `mkcert` are now grouped together under one `# Runtime GUI (web kiosk) server deps` heading instead of being split across two groups.

## Relevant logs, error messages, etc.
Verified with `mamba env create -f environment.yaml --dry-run` that the environment still solves cleanly after these changes.
