### PR TITLE
Fix off-by-one in minimum query length gate

### DIFF
--- a/commec/config/screen_io.py
+++ b/commec/config/screen_io.py
@@ -154,8 +154,8 @@ class ScreenIO:
                         f"Ensure that the first {MAXIMUM_QUERY_NAME_LENGTH} characters for each fasta record are unique."
                     )
                 queries[query.name] = query
-                # Override the original cleaned fasta, with queries above a given length and updated names
-                if MINIMUM_QUERY_LENGTH < len(record.seq) <= MAXIMUM_QUERY_LENGTH:
+                # Override the original cleaned fasta, with queries within the valid length range and updated names
+                if MINIMUM_QUERY_LENGTH <= len(record.seq) <= MAXIMUM_QUERY_LENGTH:
                     # Creating new SeqRecord to avoid overwriting the seq_record object inside query and preserve the original seq id
                     updated_records.append(
                         SeqRecord(record.seq, id=query.name, description="")

--- a/commec/tests/test_screen_io.py
+++ b/commec/tests/test_screen_io.py
@@ -2,9 +2,11 @@ import os
 from unittest.mock import patch
 
 import pytest
+from Bio import SeqIO
 from Bio.Seq import Seq
 from Bio.SeqRecord import SeqRecord
 
+from commec.config.constants import MAXIMUM_QUERY_LENGTH, MINIMUM_QUERY_LENGTH
 from commec.config.screen_io import IoValidationError, ScreenIO, substitute_non_iupac
 from commec.screen import ScreenArgumentParser, add_args
 
@@ -228,3 +230,51 @@ def test_parse_input_fasta_warns_when_substitutions_exceed_threshold(
 
     assert len(not_dna_warnings) == 1
     assert record_id in not_dna_warnings[0]
+
+
+@pytest.mark.parametrize(
+    "length,expect_in_nt_fasta",
+    [
+        pytest.param(MINIMUM_QUERY_LENGTH - 1, False, id="below_minimum"),
+        # A query of exactly MINIMUM_QUERY_LENGTH is screened rather than skipped by
+        # `screen.py`, so it must also reach the nucleotide FASTA, or it would be
+        # protein-screened only and still report as a normal pass
+        pytest.param(MINIMUM_QUERY_LENGTH, True, id="exactly_minimum"),
+        pytest.param(MINIMUM_QUERY_LENGTH + 1, True, id="above_minimum"),
+        pytest.param(MAXIMUM_QUERY_LENGTH, True, id="exactly_maximum"),
+        pytest.param(MAXIMUM_QUERY_LENGTH + 1, False, id="above_maximum"),
+    ],
+)
+def test_parse_input_fasta_length_boundaries(
+    length, expect_in_nt_fasta, database_dir, tmp_path
+):
+    input_fasta = tmp_path / "boundary.fasta"
+    sequence = "ATG" * (length // 3 + 1)
+    input_fasta.write_text(f">boundary\n{sequence[:length]}\n", encoding="utf-8")
+
+    with patch(
+        "sys.argv",
+        [
+            "test.py",
+            "--skip-tx",
+            str(input_fasta),
+            "-d",
+            database_dir,
+            "-o",
+            str(tmp_path),
+        ],
+    ):
+        parser = ScreenArgumentParser()
+        add_args(parser)
+        screen_io = ScreenIO(parser.parse_args())
+        screen_io.setup()
+
+    queries = screen_io.parse_input_fasta()
+
+    # Every record becomes a query, regardless of length, so that it can be reported on
+    assert queries["boundary"].length == length
+
+    with open(screen_io.nt_path, "r", encoding="utf-8") as nt_fasta:
+        nt_records = list(SeqIO.parse(nt_fasta, "fasta"))
+
+    assert bool(nt_records) == expect_in_nt_fasta


### PR DESCRIPTION
## Background

Two places gate queries on `MINIMUM_QUERY_LENGTH`, and they disagreed on the boundary:

* `screen_io.py` decided which records get written to the cleaned nucleotide FASTA
  (`nt_path`), admitting only `MINIMUM_QUERY_LENGTH < len(record.seq)`.
* `screen.py` decides which queries are skipped, marking `SKIP_SHORT` only when
  `query.length < MINIMUM_QUERY_LENGTH`.

`Query.length` is `len(record.seq)`, so both compare the same value. With
`MINIMUM_QUERY_LENGTH = 41`, a query of exactly 41 bp fell between them: `screen.py`
treated it as valid and screened it, but `screen_io.py` never wrote it to `nt_path`.

The result was a silent loss of screening coverage. A 41 bp query was translated to
`aa_path` and run through biorisk and protein screening, but nucleotide search had no
record to search, so it could only ever come back empty. The query was never marked
`SKIP_SHORT`, so nothing in the output indicated that a screening step had been
skipped — it reported as an ordinary result.

## Changes

### Bug fixes
* `screen_io.py` now admits records at
  `MINIMUM_QUERY_LENGTH <= len(record.seq) <= MAXIMUM_QUERY_LENGTH`, so a query of
  exactly `MINIMUM_QUERY_LENGTH` reaches `nt_path` and is nucleotide-screened. This
  matches `screen.py`'s skip condition and the user-facing rationale text, which reads
  "must be at least 41 bp". The two gates now cover the same set of queries, so no query
  can fall between them.

### Tests
* Added `test_parse_input_fasta_length_boundaries`, parameterised over all five boundary
  cases (`MINIMUM - 1`, `MINIMUM`, `MINIMUM + 1`, `MAXIMUM`, `MAXIMUM + 1`). It asserts
  both that every record becomes a `Query` regardless of length, and whether that record
  reaches `nt_path`. Verified to fail on the `exactly_minimum` case with the source fix
  reverted.